### PR TITLE
Add ActiveRecord models with tests and fixtures

### DIFF
--- a/API/app/models/area.rb
+++ b/API/app/models/area.rb
@@ -1,0 +1,11 @@
+class Area < ApplicationRecord
+  belongs_to :organization
+
+  has_many :task_types
+  has_many :jobs
+  has_many :users
+  has_many :areas_links
+  has_many :links, through: :areas_links
+
+  validates :name, presence: true
+end

--- a/API/app/models/areas_link.rb
+++ b/API/app/models/areas_link.rb
@@ -1,0 +1,6 @@
+class AreasLink < ApplicationRecord
+  belongs_to :area
+  belongs_to :link
+
+  validates :area_id, uniqueness: { scope: :link_id }
+end

--- a/API/app/models/color.rb
+++ b/API/app/models/color.rb
@@ -1,0 +1,6 @@
+class Color < ApplicationRecord
+  belongs_to :customer, optional: true
+  belongs_to :job, optional: true
+
+  validates :name, presence: true
+end

--- a/API/app/models/customer.rb
+++ b/API/app/models/customer.rb
@@ -1,0 +1,8 @@
+class Customer < ApplicationRecord
+  belongs_to :organization
+
+  has_many :jobs
+  has_many :colors
+
+  validates :name, presence: true
+end

--- a/API/app/models/job.rb
+++ b/API/app/models/job.rb
@@ -1,0 +1,9 @@
+class Job < ApplicationRecord
+  belongs_to :customer
+  belongs_to :area
+
+  has_many :tasks
+  has_many :colors
+
+  validates :ticket_no, presence: true
+end

--- a/API/app/models/link.rb
+++ b/API/app/models/link.rb
@@ -1,0 +1,6 @@
+class Link < ApplicationRecord
+  has_many :areas_links
+  has_many :areas, through: :areas_links
+
+  validates :name, presence: true
+end

--- a/API/app/models/organization.rb
+++ b/API/app/models/organization.rb
@@ -1,0 +1,7 @@
+class Organization < ApplicationRecord
+  has_many :areas
+  has_many :users
+  has_many :customers
+
+  validates :name, presence: true
+end

--- a/API/app/models/punch.rb
+++ b/API/app/models/punch.rb
@@ -1,0 +1,6 @@
+class Punch < ApplicationRecord
+  belongs_to :task
+  belongs_to :user
+
+  validates :time, presence: true
+end

--- a/API/app/models/task.rb
+++ b/API/app/models/task.rb
@@ -1,0 +1,6 @@
+class Task < ApplicationRecord
+  belongs_to :job
+  belongs_to :task_type
+
+  has_many :punches
+end

--- a/API/app/models/task_type.rb
+++ b/API/app/models/task_type.rb
@@ -1,0 +1,7 @@
+class TaskType < ApplicationRecord
+  belongs_to :area
+
+  has_many :tasks
+
+  validates :name, presence: true
+end

--- a/API/app/models/user.rb
+++ b/API/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   belongs_to :organization
   belongs_to :area, optional: true
 
+  has_many :punches
+
   has_secure_password
 
   validates :name, presence: true

--- a/API/test/fixtures/areas.yml
+++ b/API/test/fixtures/areas.yml
@@ -1,0 +1,8 @@
+main_shop:
+  organization: acme
+  name: Main Shop
+  map_file: main_shop.jpg
+
+secondary_shop:
+  organization: secondary
+  name: Secondary Shop

--- a/API/test/fixtures/areas_links.yml
+++ b/API/test/fixtures/areas_links.yml
@@ -1,0 +1,7 @@
+main_shop_spec_sheet:
+  area: main_shop
+  link: spec_sheet
+
+main_shop_safety_data:
+  area: main_shop
+  link: safety_data

--- a/API/test/fixtures/colors.yml
+++ b/API/test/fixtures/colors.yml
@@ -1,0 +1,14 @@
+matte_black:
+  customer: acme_customer
+  job: first_job
+  name: Matte Black
+  color_code: RAL9005
+  brand: Tiger Drylac
+  powder_in_stock: 25.0
+  powder_on_order: 10.0
+
+gloss_white:
+  customer: acme_customer
+  name: Gloss White
+  color_code: RAL9010
+  brand: Prismatic Powders

--- a/API/test/fixtures/customers.yml
+++ b/API/test/fixtures/customers.yml
@@ -1,0 +1,8 @@
+acme_customer:
+  organization: acme
+  name: Big Industrial Co
+  address: 789 Industrial Pkwy
+
+secondary_customer:
+  organization: secondary
+  name: Small Fab Shop

--- a/API/test/fixtures/jobs.yml
+++ b/API/test/fixtures/jobs.yml
@@ -1,0 +1,11 @@
+first_job:
+  customer: acme_customer
+  area: main_shop
+  ticket_no: 1001
+  completed_on: 2026-01-15
+  powder_used: 12.5
+
+second_job:
+  customer: acme_customer
+  area: main_shop
+  ticket_no: 1002

--- a/API/test/fixtures/links.yml
+++ b/API/test/fixtures/links.yml
@@ -1,0 +1,8 @@
+spec_sheet:
+  name: Spec Sheet
+  description: Reference specification document
+  value: https://example.com/spec-sheet
+
+safety_data:
+  name: Safety Data Sheet
+  value: https://example.com/sds

--- a/API/test/fixtures/organizations.yml
+++ b/API/test/fixtures/organizations.yml
@@ -1,0 +1,7 @@
+acme:
+  name: Acme Powder Coating
+  address: 123 Main St
+
+secondary:
+  name: Secondary Coatings Co
+  address: 456 Oak Ave

--- a/API/test/fixtures/punches.yml
+++ b/API/test/fixtures/punches.yml
@@ -1,0 +1,9 @@
+first_job_blast_punch:
+  task: first_job_blast
+  user: alice
+  time: 2026-01-10 08:05:00
+
+first_job_powder_coat_punch:
+  task: first_job_powder_coat
+  user: bob
+  time: 2026-01-11 08:05:00

--- a/API/test/fixtures/task_types.yml
+++ b/API/test/fixtures/task_types.yml
@@ -1,0 +1,9 @@
+blast:
+  area: main_shop
+  name: Blast
+  description: Media blasting prep
+
+powder_coat:
+  area: main_shop
+  name: Powder Coat
+  description: Powder application and cure

--- a/API/test/fixtures/tasks.yml
+++ b/API/test/fixtures/tasks.yml
@@ -1,0 +1,10 @@
+first_job_blast:
+  job: first_job
+  task_type: blast
+  started_at: 2026-01-10 08:00:00
+  stopped_at: 2026-01-10 09:30:00
+
+first_job_powder_coat:
+  job: first_job
+  task_type: powder_coat
+  started_at: 2026-01-11 08:00:00

--- a/API/test/fixtures/users.yml
+++ b/API/test/fixtures/users.yml
@@ -1,0 +1,14 @@
+alice:
+  organization: acme
+  area: main_shop
+  name: Alice Operator
+  username: alice
+  password_digest: <%= BCrypt::Password.create('password123') %>
+  user_level: production
+
+bob:
+  organization: acme
+  name: Bob Captain
+  username: bob
+  password_digest: <%= BCrypt::Password.create('password123') %>
+  user_level: captain

--- a/API/test/models/area_test.rb
+++ b/API/test/models/area_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class AreaTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert areas(:main_shop).valid?
+  end
+
+  test "requires a name" do
+    area = Area.new(organization: organizations(:acme), name: nil)
+    assert_not area.valid?
+    assert_includes area.errors[:name], "can't be blank"
+  end
+
+  test "requires an organization" do
+    area = Area.new(name: "Orphan Shop")
+    assert_not area.valid?
+    assert_includes area.errors[:organization], "must exist"
+  end
+
+  test "has many task_types and jobs" do
+    main_shop = areas(:main_shop)
+    assert_includes main_shop.task_types, task_types(:blast)
+    assert_includes main_shop.jobs, jobs(:first_job)
+  end
+
+  test "has many links through areas_links" do
+    assert_includes areas(:main_shop).links, links(:spec_sheet)
+    assert_includes areas(:main_shop).links, links(:safety_data)
+  end
+end

--- a/API/test/models/areas_link_test.rb
+++ b/API/test/models/areas_link_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class AreasLinkTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert areas_links(:main_shop_spec_sheet).valid?
+  end
+
+  test "requires an area and a link" do
+    areas_link = AreasLink.new
+    assert_not areas_link.valid?
+    assert_includes areas_link.errors[:area], "must exist"
+    assert_includes areas_link.errors[:link], "must exist"
+  end
+
+  test "does not allow duplicate area/link pairs" do
+    duplicate = AreasLink.new(area: areas(:main_shop), link: links(:spec_sheet))
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:area_id], "has already been taken"
+  end
+end

--- a/API/test/models/color_test.rb
+++ b/API/test/models/color_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ColorTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert colors(:matte_black).valid?
+  end
+
+  test "requires a name" do
+    color = Color.new(name: nil)
+    assert_not color.valid?
+    assert_includes color.errors[:name], "can't be blank"
+  end
+
+  test "customer and job are optional" do
+    color = Color.new(name: "Unassigned Color")
+    assert color.valid?
+  end
+end

--- a/API/test/models/customer_test.rb
+++ b/API/test/models/customer_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class CustomerTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert customers(:acme_customer).valid?
+  end
+
+  test "requires a name" do
+    customer = Customer.new(organization: organizations(:acme), name: nil)
+    assert_not customer.valid?
+    assert_includes customer.errors[:name], "can't be blank"
+  end
+
+  test "requires an organization" do
+    customer = Customer.new(name: "Orphan Customer")
+    assert_not customer.valid?
+    assert_includes customer.errors[:organization], "must exist"
+  end
+
+  test "has many jobs and colors" do
+    acme_customer = customers(:acme_customer)
+    assert_includes acme_customer.jobs, jobs(:first_job)
+    assert_includes acme_customer.colors, colors(:matte_black)
+  end
+end

--- a/API/test/models/job_test.rb
+++ b/API/test/models/job_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class JobTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert jobs(:first_job).valid?
+  end
+
+  test "requires a ticket_no" do
+    job = Job.new(customer: customers(:acme_customer), area: areas(:main_shop), ticket_no: nil)
+    assert_not job.valid?
+    assert_includes job.errors[:ticket_no], "can't be blank"
+  end
+
+  test "requires a customer and an area" do
+    job = Job.new(ticket_no: 9999)
+    assert_not job.valid?
+    assert_includes job.errors[:customer], "must exist"
+    assert_includes job.errors[:area], "must exist"
+  end
+
+  test "has many tasks and colors" do
+    first_job = jobs(:first_job)
+    assert_includes first_job.tasks, tasks(:first_job_blast)
+    assert_includes first_job.colors, colors(:matte_black)
+  end
+end

--- a/API/test/models/link_test.rb
+++ b/API/test/models/link_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class LinkTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert links(:spec_sheet).valid?
+  end
+
+  test "requires a name" do
+    link = Link.new(name: nil)
+    assert_not link.valid?
+    assert_includes link.errors[:name], "can't be blank"
+  end
+
+  test "has many areas through areas_links" do
+    assert_includes links(:spec_sheet).areas, areas(:main_shop)
+  end
+end

--- a/API/test/models/organization_test.rb
+++ b/API/test/models/organization_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class OrganizationTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert organizations(:acme).valid?
+  end
+
+  test "requires a name" do
+    organization = Organization.new(name: nil)
+    assert_not organization.valid?
+    assert_includes organization.errors[:name], "can't be blank"
+  end
+
+  test "has many areas, users, and customers" do
+    acme = organizations(:acme)
+    assert_includes acme.areas, areas(:main_shop)
+    assert_includes acme.users, users(:alice)
+    assert_includes acme.customers, customers(:acme_customer)
+  end
+end

--- a/API/test/models/punch_test.rb
+++ b/API/test/models/punch_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class PunchTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert punches(:first_job_blast_punch).valid?
+  end
+
+  test "requires a time" do
+    punch = Punch.new(task: tasks(:first_job_blast), user: users(:alice), time: nil)
+    assert_not punch.valid?
+    assert_includes punch.errors[:time], "can't be blank"
+  end
+
+  test "requires a task and a user" do
+    punch = Punch.new(time: Time.current)
+    assert_not punch.valid?
+    assert_includes punch.errors[:task], "must exist"
+    assert_includes punch.errors[:user], "must exist"
+  end
+end

--- a/API/test/models/task_test.rb
+++ b/API/test/models/task_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class TaskTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert tasks(:first_job_blast).valid?
+  end
+
+  test "requires a job and a task_type" do
+    task = Task.new
+    assert_not task.valid?
+    assert_includes task.errors[:job], "must exist"
+    assert_includes task.errors[:task_type], "must exist"
+  end
+
+  test "has many punches" do
+    assert_includes tasks(:first_job_blast).punches, punches(:first_job_blast_punch)
+  end
+end

--- a/API/test/models/task_type_test.rb
+++ b/API/test/models/task_type_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class TaskTypeTest < ActiveSupport::TestCase
+  test "valid fixture" do
+    assert task_types(:blast).valid?
+  end
+
+  test "requires a name" do
+    task_type = TaskType.new(area: areas(:main_shop), name: nil)
+    assert_not task_type.valid?
+    assert_includes task_type.errors[:name], "can't be blank"
+  end
+
+  test "requires an area" do
+    task_type = TaskType.new(name: "Orphan Task Type")
+    assert_not task_type.valid?
+    assert_includes task_type.errors[:area], "must exist"
+  end
+
+  test "has many tasks" do
+    assert_includes task_types(:blast).tasks, tasks(:first_job_blast)
+  end
+end


### PR DESCRIPTION
## Summary

Fills in the ActiveRecord layer for the API: associations and presence validations for the core domain tables, plus a model test and fixture set for each.

New models: `Area`, `AreasLink`, `Color`, `Customer`, `Job`, `Link`, `Organization`, `Punch`, `Task`, `TaskType`.
`User` picks up `has_many :punches`.

Shape of the graph:
- `Organization` owns areas, users, and customers
- `Area` belongs to an organization and owns task types, jobs, users, and links (`has_many :links, through: :areas_links`)
- `Job` belongs to a customer and an area, and owns tasks and colors

Presence validations on the identifying columns (`name`, `Job#ticket_no`, etc.).

## Testing

Adds `API/test/models/*_test.rb` covering associations and validations for each new model, with fixtures in `API/test/fixtures/`. Tests are committed but have not been run in this environment — `bin/rails test:models` still needs a pass locally before merge.

## Notes

Docker work from the same working tree is on `feature/docker` and is intentionally not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
