### PR TITLE
Add Docker Compose dev environment for API and WEB

### DIFF
--- a/API/Dockerfile.dev
+++ b/API/Dockerfile.dev
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+
+# Development image for the TIM API.
+#
+# The sibling `Dockerfile` is the production/Kamal image: it runs RAILS_ENV=production,
+# which needs RAILS_MASTER_KEY and has `config.force_ssl = true` (every plain-http
+# request gets 301'd to https), so it can't serve the local web app over
+# http://localhost:3000. This image runs the development environment instead:
+# all gem groups installed, no master key, no SSL redirect, code reloading on.
+#
+#   docker build -f API/Dockerfile.dev -t tim-api-dev ./API
+#   docker run --rm -p 3000:3000 tim-api-dev
+
+ARG RUBY_VERSION=3.4.5
+FROM docker.io/library/ruby:$RUBY_VERSION-slim
+
+WORKDIR /rails
+
+# Runtime packages plus the toolchain needed to build native gem extensions.
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      build-essential curl git libjemalloc2 libvips libyaml-dev pkg-config sqlite3 && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+ENV RAILS_ENV="development" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    RAILS_MAX_THREADS="5"
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install && rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache
+
+COPY . .
+
+EXPOSE 3000
+
+# db:prepare creates storage/development.sqlite3 and runs pending migrations on
+# first boot; it is a no-op once the database is up to date. The pid file is
+# cleared first so a stale one from a native `rails server` run (the source tree
+# is bind mounted in docker-compose.yml) doesn't block boot.
+CMD ["bash", "-c", "rm -f tmp/pids/server.pid && bundle exec rails db:prepare && bundle exec rails server -b 0.0.0.0 -p 3000"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,34 @@
 ## TIM
-
 ## How to run this web app
 
+### With Docker (recommended)
+**You only need Docker Desktop — no local Ruby, Rails, or Node required.**
+From the repository root:
+
+```
+docker compose up --build
+```
+
+This builds both images, starts the Rails API, waits for its `/up` health check to
+pass, and only then starts the Expo web server.
+
+- API: http://localhost:3000
+- WEB: http://localhost:8081
+
+Both source trees are bind mounted, so you edit files on the host as usual:
+- **API** — edits are live. Rails re-checks file timestamps on each request, so
+  the next request picks up your change; no restart needed.
+- **WEB** — edits need `docker compose restart web` (~15s, no image rebuild).
+  Metro watches with inotify, which never fires for changes made on the Windows
+  host, so the dev server does not notice them on its own.
+
+A `package.json` change does need a rebuild: `docker compose up --build web`.
+
+Add `-d` to run detached, `docker compose logs -f web` to follow the front end,
+and `docker compose down` to stop. Use `docker compose down -v` to also drop the
+Expo/node_modules caches if a dependency change stops resolving.
+
+### Without Docker
 **For Windows Users Only** (for now)
 **You must have Rails, wsl, and Node/npm installed**
 navigate to the repository and run the automations/start.ps1 powershell script
@@ -10,11 +37,11 @@ your browser should open the page. If it does not, the project is on http://loca
 
 ## Goals: 
 **Primary:** 
-    Create an inventory management system capable of tracking items, their position in storage, and their associated jobs
-    this has shifted to be more about the jobs than the inventory due to current/future needs.
+- Create an inventory management system capable of tracking items, their position in storage, and their associated jobs.
+this has shifted to be more about the jobs than the inventory due to current/future needs.
 
 **Secondary:**
-    Stay up to date on software development skills and put something on my personal GitHub for potential employers to see. 
-    Current tools I have been playing with:
-        Ollama + Claude code - using claude for planning larger context planning, with local agents for smaller tasks made by Claude. (to reduce token usage without losing the convenience)
-        Reading documentation for Github actions with plans to host the site locally for testing. started building some better startup scripts the last time I worked on this.
+- Stay up to date on software development skills and put something on my personal GitHub for potential employers to see. 
+- Current tools I have been playing with:
+    - Ollama + Claude code - using claude for planning larger context planning, with local agents for smaller tasks made by Claude. (to reduce token usage without losing the convenience) 
+    - Reading documentation for Github actions with plans to host the site locally for testing. started building some better startup scripts the last time I worked on this.

--- a/WEB/.dockerignore
+++ b/WEB/.dockerignore
@@ -1,0 +1,24 @@
+# Dependencies (reinstalled inside the image with `npm ci`)
+node_modules
+
+# Expo / Metro build output and caches
+.expo
+.expo-shared
+dist
+web-build
+.metro-health-check*
+
+# Editor / OS
+.vscode
+.DS_Store
+
+# Docker
+Dockerfile*
+.dockerignore
+
+# Logs and local env
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+.env*.local
+*.tsbuildinfo

--- a/WEB/Dockerfile
+++ b/WEB/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+# TIM web front end (Expo / React Native Web).
+#
+# Two targets:
+#   dev    (default) - Expo + Metro dev server on 8081, same as `npm start`
+#   static           - `expo export` output served by nginx on 80
+#
+# Build and run by hand:
+#   docker build -t tim-web ./WEB
+#   docker run --rm -p 8081:8081 tim-web
+# Or use docker-compose.yml at the repo root to bring up the API and web together.
+
+ARG NODE_VERSION=22
+
+# ---- deps: install node modules once, shared by the dev and build stages ----
+FROM node:${NODE_VERSION}-bookworm-slim AS deps
+WORKDIR /web
+ENV NPM_CONFIG_UPDATE_NOTIFIER=false \
+    NPM_CONFIG_FUND=false
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ---- dev: Metro dev server, hot reload when /web is bind mounted ----
+FROM deps AS dev
+# BROWSER=none stops the CLI trying to launch a browser inside the container --
+# the browser runs on the host. Do NOT set CI here: CI mode puts Metro in
+# no-watch mode and disables reloads.
+ENV BROWSER=none \
+    EXPO_NO_TELEMETRY=1
+COPY . .
+EXPOSE 8081
+CMD ["npx", "expo", "start", "--web", "--host", "lan", "--port", "8081"]
+
+# ---- build: static web export ----
+FROM deps AS build
+ENV CI=1 \
+    EXPO_NO_TELEMETRY=1
+COPY . .
+RUN npx expo export --platform web --output-dir dist
+
+# ---- static: production-ish image, no Node at runtime ----
+FROM nginx:1.27-alpine AS static
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /web/dist /usr/share/nginx/html
+EXPOSE 80

--- a/WEB/nginx.conf
+++ b/WEB/nginx.conf
@@ -1,0 +1,21 @@
+# Serves the static `expo export` output (app.json sets web.output = "static",
+# so expo-router emits one .html file per route plus a client bundle).
+server {
+    listen       80;
+    server_name  _;
+
+    root  /usr/share/nginx/html;
+    index index.html;
+
+    # /ticket/123 -> ticket/123.html -> ticket/123/index.html -> SPA fallback
+    location / {
+        try_files $uri $uri.html $uri/index.html /index.html;
+    }
+
+    # Hashed bundles/assets never change under the same name.
+    location /_expo/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+# Local TIM stack: Rails API first, then the Expo web front end.
+#
+#   docker compose up --build
+#
+# The `web` service waits for the API health check (/up) to pass before it
+# starts, so the API is always serving before Metro comes up.
+#
+#   API -> http://localhost:3000
+#   WEB -> http://localhost:8081
+
+name: tim
+
+services:
+  api:
+    build:
+      context: ./API
+      dockerfile: Dockerfile.dev
+    image: tim-api-dev
+    ports:
+      - "3000:3000"
+    volumes:
+      # Source is mounted so Rails' code reloading picks up host edits. Rails
+      # falls back to the stat-based FileUpdateChecker here (no listen gem), so
+      # reloading works over the bind mount where inotify-based watchers don't.
+      # Gems live in /usr/local/bundle, outside the mount, so they survive.
+      - ./API:/rails
+    environment:
+      RAILS_ENV: development
+      # Rails' dev host authorization allows localhost by default; add the LAN
+      # address here if you open the app from another machine.
+      # RAILS_DEVELOPMENT_HOSTS: 192.168.1.50
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/up"]
+      # Poll fast while booting so `web` starts as soon as the API answers, then
+      # back off so the health checks don't drown the development log.
+      start_period: 90s
+      start_interval: 2s
+      interval: 60s
+      timeout: 5s
+      retries: 3
+
+  web:
+    build:
+      context: ./WEB
+      target: dev
+    image: tim-web-dev
+    ports:
+      - "8081:8081"
+    volumes:
+      # Mounted so edits land in the container without an image rebuild. Note
+      # that Metro's watcher uses inotify, which gets no events from a Windows
+      # host bind mount -- run `docker compose restart web` to pick edits up.
+      - ./WEB:/web
+      # Anonymous volumes keep the container's Linux node_modules and Expo cache
+      # from being shadowed by the Windows copies in the bind mount.
+      - /web/node_modules
+      - /web/.expo
+    depends_on:
+      api:
+        condition: service_healthy


### PR DESCRIPTION
## Summary

Adds a one-command local dev environment. With Docker Desktop installed, `docker compose up --build` from the repo root brings up the Rails API and the Expo web front end — no local Ruby, Rails, or Node required.

- API: http://localhost:3000
- WEB: http://localhost:8081

## What's here

- **`API/Dockerfile.dev`** — development image for the Rails API.
- **`WEB/Dockerfile`** — multi-stage, with a shared `deps` stage and two useful targets:
  - `dev` (default) — Metro dev server on 8081, the container equivalent of `npm start`
  - `static` — `expo export` output served by nginx, no Node at runtime
- **`WEB/nginx.conf`** — serves the static export, with `try_files` matching expo-router's per-route `.html` layout and immutable caching for hashed `/_expo/` assets.
- **`WEB/.dockerignore`** — keeps `node_modules` and friends out of the build context.
- **`docker-compose.yml`** — wires the two together. `web` has `depends_on: api: condition: service_healthy`, so Metro only starts once the API's `/up` health check passes.
- **`README.md`** — documents the workflow, including the caveats below.

## Bind mount behavior (worth knowing before you use it)

Both source trees are bind mounted, but the two sides reload differently:

- **API** — edits are live. Rails uses the stat-based `FileUpdateChecker` here, which works over a bind mount where inotify watchers don't, so the next request picks up the change.
- **WEB** — edits need `docker compose restart web` (~15s, no rebuild). Metro watches via inotify, which never fires for edits made on the Windows host, so the dev server can't see them on its own.

Anonymous volumes cover `/web/node_modules` and `/web/.expo` so the container's Linux installs aren't shadowed by the Windows copies in the mount. A `package.json` change still needs `docker compose up --build web`.

## Testing

Manual only — brought the stack up locally and loaded both services. No automated tests cover the compose setup.

## Notes

Branched off `main` before #8 merged, so it doesn't contain the model work. The two touch disjoint files (this PR is Docker config plus README; #8 was `API/app/models` and `API/test`), so no conflicts are expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
