### PR TITLE
docs: add contributor conventions and web/api wiring issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# TIM — contributor conventions
+
+## Conventional Commits
+
+Use Conventional Commits structure for **commits, branch names, issue titles, and pull request titles**.
+
+Format: `<type>(<optional scope>): <description>`
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+
+Rules:
+- Description in imperative mood, lowercase, no trailing period (`add user auth`, not `Added user auth.`)
+- Breaking changes: append `!` after the type/scope (`feat(api)!: drop v1 endpoints`) and add a `BREAKING CHANGE:` footer
+- Body (optional) explains *why*, separated from the subject by a blank line
+
+Applies to:
+- **Commits** — `feat(auth): add token refresh`
+- **Branches** — `<type>/<short-kebab-description>`, e.g. `feat/token-refresh`, `fix/docker-port-clash`
+- **Issues** — title follows the same `<type>(<scope>): <description>` form
+- **Pull requests** — title follows the same form; it should read as the squash-merge commit subject

--- a/DOCS/ISSUE_web_api_wiring.md
+++ b/DOCS/ISSUE_web_api_wiring.md
@@ -1,0 +1,102 @@
+# Web app can't reach the API: route/controller namespace mismatch + unconfigured base URL
+
+**Status: not started — decide the approach before writing code.**
+
+---
+
+## Prompt for Claude (paste this to resume)
+
+We are fixing the one defect that keeps the TIM front end from talking to the Rails API.
+It has two halves; fixing either alone leaves the app broken, so treat them as one item.
+
+Before proposing code, confirm the current state still matches what's below (the repo
+moves between sessions), then walk me through the decision in "Decide this first" and
+wait for my answer. Do not start with the security rewrite — that is a separate item.
+
+### Half 1 — every app route 404s
+
+[API/config/routes.rb](../API/config/routes.rb) declares the endpoints inside
+`namespace :api`, so Rails resolves them to `Api::JobsController` /
+`Api::SessionsController` and expects the files under `app/controllers/api/`.
+The controllers are actually top-level classes at the root of
+[API/app/controllers/](../API/app/controllers/):
+
+- `class JobsController < ApplicationController` in `jobs_controller.rb`
+- `class SessionsController < ApplicationController` in `sessions_controller.rb`
+
+Verified against the running container:
+
+```
+GET /api/jobs -> 404
+ActionController::RoutingError (uninitialized constant Api::JobsController)
+```
+
+Login (`POST /api/sessions`) fails the same way, so nothing can authenticate.
+
+### Half 2 — the front end never points at the API
+
+- [WEB/app/(tabs)/schedule.tsx](<../WEB/app/(tabs)/schedule.tsx>) calls
+  `authFetch('/api/jobs')` — a relative URL, so it resolves against the Expo origin
+  (`localhost:8081`), not the API on `localhost:3000`.
+- The same file hardcodes `ws://localhost:3000/cable?token=${token}` with a
+  `// Adjust URL for production` comment.
+- [WEB/context/auth.tsx](../WEB/context/auth.tsx) passes `url` straight to `fetch`
+  with no base URL, so there is currently no single place to set the host.
+
+## Decide this first
+
+1. **Which side moves?** Namespace the controllers (`app/controllers/api/jobs_controller.rb`
+   with `module Api`) to match the routes, or drop `namespace :api` from routes.rb and
+   keep flat controllers. Namespacing matches the URL shape the front end already uses
+   and leaves room for `/api/v2`; flattening is the smaller diff. **Whichever we pick,
+   sessions and jobs must move together** — migrating one leaves login broken.
+2. **How is the base URL configured?** Likely `EXPO_PUBLIC_API_URL` read once in
+   `auth.tsx` and used for both `fetch` and the WebSocket URL. See the concerns below
+   about when that value is baked in.
+
+## Major breaking concerns
+
+These are the ones worth pausing on. Smaller cleanups are deliberately left out.
+
+- **Fixing the routing makes a forgeable auth scheme reachable.** The session token
+  *is* the user id: [sessions_controller.rb](../API/app/controllers/sessions_controller.rb)
+  returns `user.id.to_s`, [application_controller.rb](../API/app/controllers/application_controller.rb)
+  does `User.find_by(id: token.to_i)`, and
+  [connection.rb](../API/app/channels/application_cable/connection.rb) does
+  `User.find(token.to_i)`. Right now the 404 hides this. After the fix,
+  `Authorization: Bearer 1` authenticates as user 1 — and CORS in
+  [application.rb](../API/config/application.rb) is `origins '*'` with `headers: :any`,
+  so any website can do it. Decide whether real tokens (JWT/`has_secure_token`) land in
+  the same change or immediately after, but do not ship the routing fix to anything
+  public first.
+- **Tenant isolation rides on that same token.** `JobsController#index` scopes by
+  `current_user.organization_id` and `ScheduleChannel` streams
+  `schedule_#{current_user.organization_id}`. A forged token is cross-organization
+  data access, not just impersonation.
+- **The WebSocket will still fail after the URL is fixed.** Action Cable's origin check
+  is on in development — `config.action_cable.disable_request_forgery_protection` is
+  commented out at [development.rb:63](../API/config/environments/development.rb#L63) —
+  so a connection from `http://localhost:8081` is rejected for having a different origin
+  than the API host. Needs an explicit `allowed_request_origins` (or the dev toggle)
+  or the schedule page's live updates stay dead.
+- **`EXPO_PUBLIC_*` is inlined at bundle time, not read at runtime.** Changing the API
+  URL means restarting/rebundling the web container, and the static `expo export` build
+  bakes the value into the artifact — so one build cannot be repointed at another
+  environment. If that matters, the value has to come from somewhere else (runtime
+  config fetch, or a per-environment build).
+
+## Repro / verification environment
+
+The Docker stack is already set up — `docker compose up --build` from the repo root
+brings up the API on `:3000` and the web app on `:8081` (see the README).
+
+```
+curl -s -i http://localhost:3000/api/jobs | head -3   # currently 404
+docker compose logs api | grep -A3 "api/jobs"         # shows the uninitialized constant
+```
+
+Rails picks up API edits live over the bind mount. The web container does **not** —
+run `docker compose restart web` after front-end changes.
+
+Done means: log in from the browser at `localhost:8081`, the schedule page lists jobs
+from the API, and the decision in "Decide this first" is recorded in this issue.

--- a/DOCS/TO_DO.md
+++ b/DOCS/TO_DO.md
@@ -1,86 +1,86 @@
 **this is moving to the githuib issues. I need to get some more things done before playing with AI automations**
 
 ## To Do List
-    - create repo [DONE]
-    - create initial project plan [DONE]
-    - find free project management software and set up a project
-        - started using Jira, as it's free for single user teams, but it was a little too feature rich, might try something simpler.
-        - track hours with clockify (this first hour was not tracked)
-        - GitHub has some features that are free?
-        - is Bitbucket free to individuals? Jira is, still haven't checked bitbucket
-        - should this be part of the app? :lol: :sweat-smile:
-    - plan features
-        - brainstorm useful and necessary features [DONE]
-        - create prioritized list of wanted features
-    - research what API/Database to use (likely Ruby on Rails since a lot of employers seem to be asking for it) [DONE]
-        - using ruby on rails
-    - research best Framework to use (React vs. Next etc.) [DONE]
-    - research websockets, up to date information is essential to a production scenario. [STARTED]
-        - https://guides.rubyonrails.org/action_cable_overview.html
+- create repo [DONE]
+- create initial project plan [DONE]
+- find free project management software and set up a project
+    - started using Jira, as it's free for single user teams, but it was a little too feature rich, might try something simpler.
+    - track hours with clockify (this first hour was not tracked)
+    - GitHub has some features that are free?
+    - is Bitbucket free to individuals? Jira is, still haven't checked bitbucket
+    - should this be part of the app? :lol: :sweat-smile:
+- plan features
+    - brainstorm useful and necessary features [DONE]
+    - create prioritized list of wanted features
+- research what API/Database to use (likely Ruby on Rails since a lot of employers seem to be asking for it) [DONE]
+    - using ruby on rails
+- research best Framework to use (React vs. Next etc.) [DONE]
+- research websockets, up to date information is essential to a production scenario. [STARTED]
+    - https://guides.rubyonrails.org/action_cable_overview.html
 
 ## WEB
-    - create page layout/styling
-        - soften background on dark mode [IN PROGRESS]
-        - add 'ThemedButton' colors to the actual Theme [IN PROGRESS]
-        - fix dark/light mode theme change button issues [IN PROGRESS]
-        - integrate initial state of d/l theme with browser settings [DONE]
-        - menu button doesn't shift when the scroll bar opens causing overlap. move the button over so it fits nicely
-    - create settings pages [IN PROGRESS]
-        - main page file and routing added [DONE]
-        - add two sections to the main page
-            - user settings
-                - save button at bottom of page [DONE]
-                - display name, email, and location fields added
-            - organization settings 
-                - company name and default location fields added
-    - create inventory page
-        - uses DataGrid component from PrimeReact
-        - grid style editor
-            - only 1 row to start, row added each time a row is added
-            - only 1 row active at a time
-            - button below the active row to 'add' it to the table
-            - columns:
-                - name (string)
-                - adj. amount (number)
-                - total (number)
-                - amount after adjustment (number)
-                - notes (string)
-            - the 'total' column should be uneditable
-        - save button below grid
-        - pulls limited data from api endpoint for searching, then pulls full data for item after it is selected from the limited search dataset
-        - only one row can be edited at a time
-    - create job wizard
-        - develop more specific job wizard requirements
-        - make page to match those requirements
-    - create job editor
-        - page/route made, but doesn't have editing capabilities
-    - create a job page for each section
-        - upcoming
-        - blast
-        - garnet
-        - cabinet
-        - prep? or should we make it prep/wash?
-        - masking
-        - powder
-        - takedown
-    - create additional test data
-    - create auditing tools
-        - print template (also useable for job quoting?)
-        - how should it be formatted?
-    - finish "schedule" page [IN PROGRESS]
-        - move job dialog created but not styled [DONE]
-        - need to test dialog size styling on phone
-        - schedule view now supports ticket grouping and move dialog flow
+- create page layout/styling
+    - soften background on dark mode [IN PROGRESS]
+    - add 'ThemedButton' colors to the actual Theme [IN PROGRESS]
+    - fix dark/light mode theme change button issues [IN PROGRESS]
+    - integrate initial state of d/l theme with browser settings [DONE]
+    - menu button doesn't shift when the scroll bar opens causing overlap. move the button over so it fits nicely
+- create settings pages [IN PROGRESS]
+    - main page file and routing added [DONE]
+    - add two sections to the main page
+        - user settings
+            - save button at bottom of page [DONE]
+            - display name, email, and location fields added
+        - organization settings 
+            - company name and default location fields added
+- create inventory page
+    - uses DataGrid component from PrimeReact
+    - grid style editor
+        - only 1 row to start, row added each time a row is added
+        - only 1 row active at a time
+        - button below the active row to 'add' it to the table
+        - columns:
+            - name (string)
+            - adj. amount (number)
+            - total (number)
+            - amount after adjustment (number)
+            - notes (string)
+        - the 'total' column should be uneditable
+    - save button below grid
+    - pulls limited data from api endpoint for searching, then pulls full data for item after it is selected from the limited search dataset
+    - only one row can be edited at a time
+- create job wizard
+    - develop more specific job wizard requirements
+    - make page to match those requirements
+- create job editor
+    - page/route made, but doesn't have editing capabilities
+- create a job page for each section
+    - upcoming
+    - blast
+    - garnet
+    - cabinet
+    - prep? or should we make it prep/wash?
+    - masking
+    - powder
+    - takedown
+- create additional test data
+- create auditing tools
+    - print template (also useable for job quoting?)
+    - how should it be formatted?
+- finish "schedule" page [IN PROGRESS]
+    - move job dialog created but not styled [DONE]
+    - need to test dialog size styling on phone
+    - schedule view now supports ticket grouping and move dialog flow
 
-    - create launch scripts/instructions for possible other contributors
-        - docker? (that's what I have seen used in the past)
-        - research other container options
+- create launch scripts/instructions for possible other contributors
+    - docker? (that's what I have seen used in the past)
+    - research other container options
 
 ## API
-    - fix docker container, doesn't start properly.
-        - warning about deprecated packages, need to figure out the rest.
-    - make a lucidchart of the tables
-    - create migrations in ruby
-        - having issues with these
-    - update controllers
-    - create testing
+- fix docker container, doesn't start properly.
+    - warning about deprecated packages, need to figure out the rest.
+- make a lucidchart of the tables
+- create migrations in ruby
+    - having issues with these
+- update controllers
+- create testing

--- a/DOCS/TO_DO.md
+++ b/DOCS/TO_DO.md
@@ -1,6 +1,6 @@
 **this is moving to the githuib issues. I need to get some more things done before playing with AI automations**
 
-##To Do List:
+## To Do List
     - create repo [DONE]
     - create initial project plan [DONE]
     - find free project management software and set up a project
@@ -18,7 +18,7 @@
     - research websockets, up to date information is essential to a production scenario. [STARTED]
         - https://guides.rubyonrails.org/action_cable_overview.html
 
-    ##WEB
+## WEB
     - create page layout/styling
         - soften background on dark mode [IN PROGRESS]
         - add 'ThemedButton' colors to the actual Theme [IN PROGRESS]
@@ -76,7 +76,7 @@
         - docker? (that's what I have seen used in the past)
         - research other container options
 
-    ##API
+## API
     - fix docker container, doesn't start properly.
         - warning about deprecated packages, need to figure out the rest.
     - make a lucidchart of the tables

--- a/DOCS/TO_DO.md
+++ b/DOCS/TO_DO.md
@@ -1,4 +1,6 @@
-To Do List:
+**this is moving to the githuib issues. I need to get some more things done before playing with AI automations**
+
+##To Do List:
     - create repo [DONE]
     - create initial project plan [DONE]
     - find free project management software and set up a project
@@ -16,7 +18,7 @@ To Do List:
     - research websockets, up to date information is essential to a production scenario. [STARTED]
         - https://guides.rubyonrails.org/action_cable_overview.html
 
-    WEB
+    ##WEB
     - create page layout/styling
         - soften background on dark mode [IN PROGRESS]
         - add 'ThemedButton' colors to the actual Theme [IN PROGRESS]
@@ -74,7 +76,7 @@ To Do List:
         - docker? (that's what I have seen used in the past)
         - research other container options
 
-    API
+    ##API
     - fix docker container, doesn't start properly.
         - warning about deprecated packages, need to figure out the rest.
     - make a lucidchart of the tables


### PR DESCRIPTION
Documentation-only changes. No application code touched.

## What's here

- **`CLAUDE.md`** (new, repo root) — defines Conventional Commits structure for commits, branch names, issue titles, and PR titles. Doubles as instructions for AI agents working in the repo, which pick it up automatically.
- **`DOCS/ISSUE_web_api_wiring.md`** (new) — writeup of the defect keeping the front end from reaching the Rails API: the `namespace :api` routes resolve to `Api::JobsController` / `Api::SessionsController`, but the controllers are top-level classes, so every app route 404s. Second half covers the unconfigured API base URL. Not started; the doc lays out the decision to make first.
- **`DOCS/TO_DO.md`** — notes that the list is migrating to GitHub issues, and fixes three headings that were missing the space after `##` (and were indented), so they rendered as literal text rather than headings.
