### PR TITLE
docs: record open issues and sequence them into milestones

### DIFF
--- a/DOCS/TO_DO.md
+++ b/DOCS/TO_DO.md
@@ -1,5 +1,11 @@
 **this is moving to the githuib issues. I need to get some more things done before playing with AI automations**
 
+## GitHub Issues (open)
+- #10 — Web app can't reach the API: route/controller namespace mismatch + unconfigured base URL (bug) — https://github.com/jmunyan/TIM/issues/10
+- #6 — move to do list to project (documentation) — https://github.com/jmunyan/TIM/issues/6
+- #5 — change the theme button to a toggle switch (enhancement) — https://github.com/jmunyan/TIM/issues/5
+- #4 — some text not visible in light mode (bug) — https://github.com/jmunyan/TIM/issues/4
+
 ## To Do List
 - create repo [DONE]
 - create initial project plan [DONE]
@@ -84,3 +90,143 @@
     - having issues with these
 - update controllers
 - create testing
+
+## Code Issues Found (codebase sweep, 2026-08-20)
+
+Found by reading the whole codebase and verified against source. Anything already
+covered by GitHub issues #4, #5, #6, #10 or by the lists above is **not** repeated
+here; where a new item sits close to an existing one, the difference is stated.
+
+### Blocking — /api/jobs cannot succeed, even after the routing fix in issue #10
+
+- **`jobs` has no `organization_id` column, but the controller scopes on it.**
+  `API/app/controllers/jobs_controller.rb:5` does `where(organization_id: current_user.organization_id)`;
+  the jobs table (`API/db/schema.rb:59-71`) has only customer_id, area_id, ticket_no,
+  completed_on, powder_used, deleted_at, timestamps. The query raises
+  `no such column: jobs.organization_id`. `Job` also has no `belongs_to :organization`,
+  and `broadcast_update` reads `job.organization_id` at line 30.
+  *Differs from issue #10:* that item is about the tenant scope being **forgeable**;
+  this is that the scope **does not run at all** because the column is missing.
+- **`job.color` is not a thing.** `Job` declares `has_many :colors`
+  (`API/app/models/job.rb:6`), but the controller calls singular `job.color&.name`
+  (`jobs_controller.rb:18`) — NoMethodError.
+- **`job.notes` and `job.description` are not columns.** Rendered at
+  `jobs_controller.rb:17` and `:19`, absent from the jobs table. The front end maps
+  both into every ticket (`WEB/app/(tabs)/schedule.tsx:45,47`).
+
+### API
+
+- **No route creates or updates a job.** `API/config/routes.rb:11-15` declares only
+  `POST /api/sessions`, `DELETE /api/session`, `GET /api/jobs`. The new-ticket form and
+  the move-ticket dialog have no endpoint to call.
+- **Session route paths disagree:** `post 'sessions'` (plural) vs `delete 'session'`
+  (singular), `routes.rb:12-13`.
+- **`broadcast_update` is never called.** `jobs_controller.rb:29-34` is a public method
+  on the controller that nothing invokes, so no job change is ever broadcast — live
+  updates cannot fire even once the socket connects.
+- **A missing Action Cable token is not rejected.**
+  `API/app/channels/application_cable/connection.rb:13` returns nil when no token is
+  present (only the `rescue` calls `reject_unauthorized_connection`), so
+  `ScheduleChannel#subscribed` then calls `.organization_id` on nil
+  (`API/app/channels/schedule_channel.rb:3`).
+- **Bare `rescue` swallows everything.** `connection.rb:14` catches any StandardError,
+  so an unrelated bug in the connection path is reported as a failed login.
+- **Soft deletes are never applied.** Ten of the eleven tables carry a `deleted_at` column
+  (`API/db/schema.rb` -- all but `areas_links`), and no model has a default scope or filter for it — every
+  query returns deleted rows.
+- **A `Color` belongs to both a customer and a job, both optional**
+  (`API/app/models/color.rb:2-3`). Nothing enforces exactly one, and it isn't defined
+  whether a color row is a customer's palette entry or a job's chosen coating.
+- **Two competing time-tracking mechanisms.** `tasks.started_at`/`stopped_at`
+  (`schema.rb:111-121`) and the whole `punches` table (`schema.rb:90-99`). Decide which
+  is authoritative before either is used.
+- **Dead duplicate CORS config.** `API/config/initializers/cors.rb` is commented out end
+  to end while the live rule sits in `API/config/application.rb:33-38`.
+  *Differs from issue #10:* that item is about the `origins '*'` **value**; this is
+  about there being two places to look, one of them inert.
+- **`Task` is the only model with no validations** (`API/app/models/task.rb`).
+- **Kamal deploy target is still a placeholder:** `image: your-user/api`,
+  `API/config/deploy.yml:5`.
+
+### CI and tests
+
+- **CI has never run.** The workflow is at `API/.github/workflows/ci.yml`, but GitHub
+  Actions only reads `.github/workflows/` at the **repository root**, and there is no
+  root `.github/` directory. Brakeman, RuboCop and the test job are all inert.
+- **Tests cover models only** — 35 tests across 10 files in `API/test/models/`, and no
+  controller, request or channel test anywhere -- `API/test/controllers/` and
+  `API/test/integration/` hold only a `.keep`, and `API/test/channels/` does not exist. One request test against `/api/jobs`
+  would have caught all three blocking items above.
+- **No front-end tests at all.** `WEB/package.json` has no `test` script, and `expo lint`
+  is never run by anything.
+
+### WEB
+
+- **Nothing ever calls `login()`.** It is defined at `WEB/context/auth.tsx:26`, imported
+  by no component, and there is no login route in `WEB/app/_layout.tsx`. `token` is only
+  ever read back from localStorage, which nothing writes — so `if (!token) return;` at
+  `schedule.tsx:36` means the schedule is permanently empty.
+  *Differs from issue #10:* that is the API returning 404 to a login attempt; this is
+  that the client has no screen from which to attempt one.
+- **Web-only APIs in an app that ships iOS and Android targets.** Each crashes or no-ops
+  on native:
+    - `localStorage` unguarded in `WEB/context/auth.tsx:18,19,29,30,36,37`
+      (`WEB/context/theme.tsx:25,34` guards the same call with `typeof window`)
+    - `alert()` in `WEB/app/new-ticket.tsx:51,62`
+    - a raw `<div>` and CSS `float` in `WEB/components/Dialogs/DialogFooter.tsx:8-10`
+    - a `'50vw'` unit in `WEB/components/Dialogs/MoveTicketDialog.tsx:73`
+- **"Create ticket" creates nothing and says it did.** `new-ticket.tsx:49-64` console.logs
+  the payload, shows `alert('Ticket created successfully.')`, and navigates away.
+- **Moving a ticket is not persisted.** `schedule.tsx:167-180` updates local state only;
+  a refresh reverts it.
+  *Differs from "move job dialog created but not styled" above:* that item is appearance,
+  this is that the result is never saved.
+- **"Save settings" discards every field.** `WEB/app/settings/[userId].tsx:59-64` — the
+  button's `onPress` is `router.push('/schedule')`, and none of display name, email,
+  company or location goes anywhere.
+  *Differs from "save button at bottom of page [DONE]" above:* the button exists, which
+  is what was done; it was never wired to anything.
+- **The ticket detail page shows fabricated data.** `WEB/app/ticket/[ticketId].tsx:16-19`
+  hardcodes "Sample Customer", "Status: New", "Location: Upcoming" and never fetches.
+  *Differs from "create job editor" above:* that is the editor page; this is the
+  read-only view reached by the "Go To Ticket" button.
+- **The section list is duplicated verbatim in two files** — `schedule.tsx:13-23` and
+  `MoveTicketDialog.tsx:20-30`.
+- **A third section list contradicts both.** The `Ticket.location` union at
+  `WEB/constants/Ticket.ts:11` allows `Receiving` and `Shipping`, which exist nowhere
+  else, and omits `Garnet`, `Cabinet` and `Invoice`, which both other lists have.
+  *Differs from the item above:* that is the same list copied twice; this is a third
+  list that disagrees with the copies.
+- **Sections are matched against database values with no guarantee they agree.**
+  `ticketsBySection` filters on `ticket.location === section` (`schedule.tsx:150`), and
+  `location` is `area.name` straight from the DB (`jobs_controller.rb:16`). Any area
+  whose name isn't exactly one of the nine strings drops its tickets silently.
+  *Differs from the two items above:* those are code disagreeing with code; this is code
+  disagreeing with the database.
+- **`authFetch` is rebuilt on every AuthProvider render** (`auth.tsx:40`, not memoised)
+  and sits in the effect's dependency array (`schedule.tsx:54`), so jobs are refetched
+  whenever the provider re-renders, not only when the token changes.
+- **Subscription failures are invisible.** The socket's `onmessage`
+  (`schedule.tsx:71-83`) handles only `ping` and `job_updated`, ignoring Action Cable's
+  `confirm_subscription` and `reject_subscription`. Given the nil-user rejection above,
+  a rejected subscription looks exactly like an idle connection. `onclose` only logs —
+  there is no reconnect.
+- **Part ids collide.** `addPart` uses `id: prev.length + 1`
+  (`new-ticket.tsx:36`), so removing part 2 of 3 and adding one yields two parts with
+  id 3 — and `id` is the React key.
+- **The new-ticket form collects data the schema cannot store.** Parts, quantities and
+  masking flags (`new-ticket.tsx:7-13`) have no table; the schema goes jobs -> tasks with
+  no parts concept.
+- **The menu always opens user 1's settings.** `WEB/components/DropdownMenu.tsx:38`
+  pushes `/settings/1` regardless of who is signed in.
+- **PrimeReact is pinned to a light theme.** `schedule.tsx:6` imports
+  `primereact/resources/themes/lara-light-cyan/theme.css`, so the move-ticket dialog
+  stays light while the app is in dark mode.
+  *Differs from issue #4:* that is the app's own palette in light mode; this is a
+  third-party stylesheet locked to light.
+- **The default auth context fails silently.** `auth.tsx:8` defaults `authFetch` to
+  `Promise.resolve(new Response())`, so a component rendered outside the provider gets
+  an empty 200 and `res.json()` throws, instead of a clear "no provider" error.
+- **`MoveTicketDialog` never clears `note`** (`MoveTicketDialog.tsx:33-39` resets only
+  `selectedSection`), so the previous ticket's note is prefilled into the next one.
+- **TicketCard prints the PO twice** — `WEB/components/TicketCard.tsx:38` and `:41`.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ pass, and only then starts the Expo web server.
 - WEB: http://localhost:8081
 
 Both source trees are bind mounted, so you edit files on the host as usual:
-- **API** — edits are live. Rails re-checks file timestamps on each request, so
-  the next request picks up your change; no restart needed.
+- **API** — edits are live except migrations (run `docker compose restart api`).
+  Rails re-checks file timestamps on each request, so the next request picks up
+  your change; no restart needed.
 - **WEB** — edits need `docker compose restart web` (~15s, no image rebuild).
   Metro watches with inotify, which never fires for changes made on the Windows
   host, so the dev server does not notice them on its own.
@@ -43,5 +44,4 @@ this has shifted to be more about the jobs than the inventory due to current/fut
 **Secondary:**
 - Stay up to date on software development skills and put something on my personal GitHub for potential employers to see. 
 - Current tools I have been playing with:
-    - Ollama + Claude code - using claude for planning larger context planning, with local agents for smaller tasks made by Claude. (to reduce token usage without losing the convenience) 
-    - Reading documentation for Github actions with plans to host the site locally for testing. started building some better startup scripts the last time I worked on this.
+    - Claude Code

--- a/dossiers/tim-issue-milestones/.waves/wave-01.json
+++ b/dossiers/tim-issue-milestones/.waves/wave-01.json
@@ -1,0 +1,843 @@
+{
+  "label": "Wave 1 - dependency and co-location graph across the 46 entries",
+  "question": "Which entries block which, and which touch the same files?",
+  "ran_at": "2026-08-20 07:57",
+  "run": {
+    "ok": true,
+    "model": "gemma4:latest",
+    "wave_wall_s": 55.65,
+    "results": [
+      {
+        "drone": "Cottus",
+        "focus": "every file path, stated dependency, cross-reference and code identifier in these register rows",
+        "ok": true,
+        "data": {
+          "items": [
+            {
+              "entry": "gh#10 web app cannot reach the API: namespace mismatch and unconfigured base URL",
+              "kind": "ghref",
+              "value": "10",
+              "quote": "https://github.com/jmunyan/TIM/issues/10"
+            },
+            {
+              "entry": "gh#10 web app cannot reach the API: namespace mismatch and unconfigured base URL",
+              "kind": "path",
+              "value": "DOCS/ISSUE_web_api_wiring.md",
+              "quote": ""
+            },
+            {
+              "entry": "gh#10 web app cannot reach the API: namespace mismatch and unconfigured base URL",
+              "kind": "dependency",
+              "value": "unblocks most of the sweep entries",
+              "quote": "Fixing it unblocks most of the sweep entries."
+            },
+            {
+              "entry": "Nothing ever calls login and there is no login screen",
+              "kind": "path",
+              "value": "auth.tsx:26",
+              "quote": ""
+            },
+            {
+              "entry": "Nothing ever calls login and there is no login screen",
+              "kind": "path",
+              "value": "app/_layout.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "Nothing ever calls login and there is no login screen",
+              "kind": "path",
+              "value": "schedule.tsx:36",
+              "quote": ""
+            },
+            {
+              "entry": "Nothing ever calls login and there is no login screen",
+              "kind": "dependency",
+              "value": "API 404ing a login attempt",
+              "quote": "Distinct from gh#10: that is the API 404ing a login attempt, this is having no screen to attempt one from."
+            },
+            {
+              "entry": "Nothing ever calls login and there is no login screen",
+              "kind": "distinction",
+              "value": "",
+              "quote": "Distinct from gh#10: that is the API 404ing a login attempt, this is having no screen to attempt one from."
+            },
+            {
+              "entry": "Action Cable does not reject a connection with no token",
+              "kind": "path",
+              "value": "connection.rb:13",
+              "quote": ""
+            },
+            {
+              "entry": "Action Cable does not reject a connection with no token",
+              "kind": "path",
+              "value": "schedule_channel.rb:3",
+              "quote": ""
+            },
+            {
+              "entry": "Tests cover models only",
+              "kind": "path",
+              "value": "API/test/models/",
+              "quote": ""
+            },
+            {
+              "entry": "Tests cover models only",
+              "kind": "path",
+              "value": "API/test/controllers/",
+              "quote": ""
+            },
+            {
+              "entry": "Tests cover models only",
+              "kind": "path",
+              "value": "API/test/integration/",
+              "quote": ""
+            },
+            {
+              "entry": "Tests cover models only",
+              "kind": "path",
+              "value": "API/test/channels/",
+              "quote": ""
+            },
+            {
+              "entry": "Tests cover models only",
+              "kind": "dependency",
+              "value": "One request test against /api/jobs would have caught all three blocking entries.",
+              "quote": "One request test against /api/jobs would have caught all three blocking entries."
+            },
+            {
+              "entry": "Ten tables carry deleted_at and no model ever filters on it",
+              "kind": "path",
+              "value": "schema.rb",
+              "quote": ""
+            },
+            {
+              "entry": "Ten tables carry deleted_at and no model ever filters on it",
+              "kind": "path",
+              "value": "API/app/models",
+              "quote": ""
+            },
+            {
+              "entry": "Ten tables carry deleted_at and no model ever filters on it",
+              "kind": "symbol",
+              "value": "deleted_at",
+              "quote": ""
+            },
+            {
+              "entry": "Ten tables carry deleted_at and no model ever filters on it",
+              "kind": "symbol",
+              "value": "default_scope",
+              "quote": ""
+            },
+            {
+              "entry": "Ten tables carry deleted_at and no model ever filters on it",
+              "kind": "symbol",
+              "value": "discard",
+              "quote": ""
+            },
+            {
+              "entry": "Ten tables carry deleted_at and no model ever filters on it",
+              "kind": "symbol",
+              "value": "paranoia",
+              "quote": ""
+            },
+            {
+              "entry": "Ticket detail page shows fabricated sample data",
+              "kind": "path",
+              "value": "ticket/[ticketId].tsx:16-19",
+              "quote": ""
+            },
+            {
+              "entry": "Ticket detail page shows fabricated sample data",
+              "kind": "symbol",
+              "value": "ticketId",
+              "quote": ""
+            },
+            {
+              "entry": "Ticket detail page shows fabricated sample data",
+              "kind": "distinction",
+              "value": "",
+              "quote": "Different page from the job editor already on the to-do list; this is the read-only view behind 'Go To Ticket'."
+            },
+            {
+              "entry": "Bare rescue in find_verified_user masks unrelated errors",
+              "kind": "path",
+              "value": "connection.rb:14",
+              "quote": ""
+            },
+            {
+              "entry": "Bare rescue in find_verified_user masks unrelated errors",
+              "kind": "symbol",
+              "value": "find_verified_user",
+              "quote": ""
+            },
+            {
+              "entry": "Ticket.location type contradicts both section lists",
+              "kind": "path",
+              "value": "constants/Ticket.ts:11",
+              "quote": ""
+            },
+            {
+              "entry": "Ticket.location type contradicts both section lists",
+              "kind": "symbol",
+              "value": "Ticket.location",
+              "quote": ""
+            },
+            {
+              "entry": "Ticket.location type contradicts both section lists",
+              "kind": "dependency",
+              "value": "Related to the duplication entry but a different defect: a third list that disagrees.",
+              "quote": "Related to the duplication entry but a different defect: a third list that disagrees."
+            },
+            {
+              "entry": "PrimeReact is pinned to a light theme",
+              "kind": "path",
+              "value": "schedule.tsx:6",
+              "quote": ""
+            },
+            {
+              "entry": "PrimeReact is pinned to a light theme",
+              "kind": "path",
+              "value": "lara-light-cyan/theme.css",
+              "quote": ""
+            },
+            {
+              "entry": "PrimeReact is pinned to a light theme",
+              "kind": "distinction",
+              "value": "",
+              "quote": "Different from gh#4, which is the app's own palette in light mode."
+            },
+            {
+              "entry": "gh#5 change the theme button to a toggle switch",
+              "kind": "ghref",
+              "value": "5",
+              "quote": "https://github.com/jmunyan/TIM/issues/5"
+            },
+            {
+              "entry": "gh#5 change the theme button to a toggle switch",
+              "kind": "path",
+              "value": "DropdownMenu.tsx:25-33",
+              "quote": ""
+            },
+            {
+              "entry": "The default auth context returns an empty 200 instead of failing loudly",
+              "kind": "path",
+              "value": "auth.tsx:8",
+              "quote": ""
+            },
+            {
+              "entry": "The default auth context returns an empty 200 instead of failing loudly",
+              "kind": "symbol",
+              "value": "authFetch",
+              "quote": ""
+            },
+            {
+              "entry": "Should the prep job section be split into prep and wash",
+              "kind": "symbol",
+              "value": "prep job section",
+              "quote": ""
+            }
+          ]
+        },
+        "raw": "{\n  \"items\": [\n    {\n      \"entry\": \"gh#10 web app cannot reach the API: namespace mismatch and unconfigured base URL\",\n      \"kind\": \"ghref\",\n      \"value\": \"10\",\n      \"quote\": \"https://github.com/jmunyan/TIM/issues/10\"\n    },\n    {\n      \"entry\": \"gh#10 web app cannot reach the API: namespace mismatch and unconfigured base URL\",\n      \"kind\": \"path\",\n      \"value\": \"DOCS/ISSUE_web_api_wiring.md\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"gh#10 web app cannot reach the API: namespace mismatch and unconfigured base URL\",\n      \"kind\": \"dependency\",\n      \"value\": \"unblocks most of the sweep entries\",\n      \"quote\": \"Fixing it unblocks most of the sweep entries.\"\n    },\n    {\n      \"entry\": \"Nothing ever calls login and there is no login screen\",\n      \"kind\": \"path\",\n      \"value\": \"auth.tsx:26\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Nothing ever calls login and there is no login screen\",\n      \"kind\": \"path\",\n      \"value\": \"app/_layout.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Nothing ever calls login and there is no login screen\",\n      \"kind\": \"path\",\n      \"value\": \"schedule.tsx:36\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Nothing ever calls login and there is no login screen\",\n      \"kind\": \"dependency\",\n      \"value\": \"API 404ing a login attempt\",\n      \"quote\": \"Distinct from gh#10: that is the API 404ing a login attempt, this is having no screen to attempt one from.\"\n    },\n    {\n      \"entry\": \"Nothing ever calls login and there is no login screen\",\n      \"kind\": \"distinction\",\n      \"value\": \"\",\n      \"quote\": \"Distinct from gh#10: that is the API 404ing a login attempt, this is having no screen to attempt one from.\"\n    },\n    {\n      \"entry\": \"Action Cable does not reject a connection with no token\",\n      \"kind\": \"path\",\n      \"value\": \"connection.rb:13\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Action Cable does not reject a connection with no token\",\n      \"kind\": \"path\",\n      \"value\": \"schedule_channel.rb:3\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Tests cover models only\",\n      \"kind\": \"path\",\n      \"value\": \"API/test/models/\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Tests cover models only\",\n      \"kind\": \"path\",\n      \"value\": \"API/test/controllers/\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Tests cover models only\",\n      \"kind\": \"path\",\n      \"value\": \"API/test/integration/\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Tests cover models only\",\n      \"kind\": \"path\",\n      \"value\": \"API/test/channels/\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Tests cover models only\",\n      \"kind\": \"dependency\",\n      \"value\": \"One request test against /api/jobs would have caught all three blocking entries.\",\n      \"quote\": \"One request test against /api/jobs would have caught all three blocking entries.\"\n    },\n    {\n      \"entry\": \"Ten tables carry deleted_at and no model ever filters on it\",\n      \"kind\": \"path\",\n      \"value\": \"schema.rb\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ten tables carry deleted_at and no model ever filters on it\",\n      \"kind\": \"path\",\n      \"value\": \"API/app/models\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ten tables carry deleted_at and no model ever filters on it\",\n      \"kind\": \"symbol\",\n      \"value\": \"deleted_at\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ten tables carry deleted_at and no model ever filters on it\",\n      \"kind\": \"symbol\",\n      \"value\": \"default_scope\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ten tables carry deleted_at and no model ever filters on it\",\n      \"kind\": \"symbol\",\n      \"value\": \"discard\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ten tables carry deleted_at and no model ever filters on it\",\n      \"kind\": \"symbol\",\n      \"value\": \"paranoia\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ticket detail page shows fabricated sample data\",\n      \"kind\": \"path\",\n      \"value\": \"ticket/[ticketId].tsx:16-19\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ticket detail page shows fabricated sample data\",\n      \"kind\": \"symbol\",\n      \"value\": \"ticketId\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ticket detail page shows fabricated sample data\",\n      \"kind\": \"distinction\",\n      \"value\": \"\",\n      \"quote\": \"Different page from the job editor already on the to-do list; this is the read-only view behind 'Go To Ticket'.\"\n    },\n    {\n      \"entry\": \"Bare rescue in find_verified_user masks unrelated errors\",\n      \"kind\": \"path\",\n      \"value\": \"connection.rb:14\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Bare rescue in find_verified_user masks unrelated errors\",\n      \"kind\": \"symbol\",\n      \"value\": \"find_verified_user\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ticket.location type contradicts both section lists\",\n      \"kind\": \"path\",\n      \"value\": \"constants/Ticket.ts:11\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ticket.location type contradicts both section lists\",\n      \"kind\": \"symbol\",\n      \"value\": \"Ticket.location\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Ticket.location type contradicts both section lists\",\n      \"kind\": \"dependency\",\n      \"value\": \"Related to the duplication entry but a different defect: a third list that disagrees.\",\n      \"quote\": \"Related to the duplication entry but a different defect: a third list that disagrees.\"\n    },\n    {\n      \"entry\": \"PrimeReact is pinned to a light theme\",\n      \"kind\": \"path\",\n      \"value\": \"schedule.tsx:6\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"PrimeReact is pinned to a light theme\",\n      \"kind\": \"path\",\n      \"value\": \"lara-light-cyan/theme.css\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"PrimeReact is pinned to a light theme\",\n      \"kind\": \"distinction\",\n      \"value\": \"\",\n      \"quote\": \"Different from gh#4, which is the app's own palette in light mode.\"\n    },\n    {\n      \"entry\": \"gh#5 change the theme button to a toggle switch\",\n      \"kind\": \"ghref\",\n      \"value\": \"5\",\n      \"quote\": \"https://github.com/jmunyan/TIM/issues/5\"\n    },\n    {\n      \"entry\": \"gh#5 change the theme button to a toggle switch\",\n      \"kind\": \"path\",\n      \"value\": \"DropdownMenu.tsx:25-33\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"The default auth context returns an empty 200 instead of failing loudly\",\n      \"kind\": \"path\",\n      \"value\": \"auth.tsx:8\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"The default auth context returns an empty 200 instead of failing loudly\",\n      \"kind\": \"symbol\",\n      \"value\": \"authFetch\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Should the prep job section be split into prep and wash\",\n      \"kind\": \"symbol\",\n      \"value\": \"prep job section\",\n      \"quote\": \"\"\n    }\n  ]\n}",
+        "note": null,
+        "retries": 0,
+        "usage": {
+          "in_tokens": 1466,
+          "out_tokens": 2029,
+          "wall_s": 48.33,
+          "load_s": 2.65,
+          "eval_s": 43.59
+        }
+      },
+      {
+        "drone": "Briareus",
+        "focus": "every file path, stated dependency, cross-reference and code identifier in these register rows",
+        "ok": true,
+        "data": {
+          "items": [
+            {
+              "entry": "Job has_many colors but the controller calls job.color",
+              "kind": "symbol",
+              "value": "job.color",
+              "quote": ""
+            },
+            {
+              "entry": "Job has_many colors but the controller calls job.color",
+              "kind": "path",
+              "value": "job.rb:6",
+              "quote": ""
+            },
+            {
+              "entry": "Job has_many colors but the controller calls job.color",
+              "kind": "path",
+              "value": "jobs_controller.rb:18",
+              "quote": ""
+            },
+            {
+              "entry": "CI has never run because the workflow is not at the repo root",
+              "kind": "path",
+              "value": "API/.github/workflows/ci.yml",
+              "quote": ""
+            },
+            {
+              "entry": "CI has never run because the workflow is not at the repo root",
+              "kind": "symbol",
+              "value": "Brakeman",
+              "quote": ""
+            },
+            {
+              "entry": "CI has never run because the workflow is not at the repo root",
+              "kind": "symbol",
+              "value": "RuboCop",
+              "quote": ""
+            },
+            {
+              "entry": "CI has never run because the workflow is not at the repo root",
+              "kind": "symbol",
+              "value": "test job",
+              "quote": ""
+            },
+            {
+              "entry": "broadcast_update is never called",
+              "kind": "symbol",
+              "value": "broadcast_update",
+              "quote": ""
+            },
+            {
+              "entry": "broadcast_update is never called",
+              "kind": "path",
+              "value": "jobs_controller.rb:29-34",
+              "quote": ""
+            },
+            {
+              "entry": "broadcast_update is never called",
+              "kind": "xref",
+              "value": "how-should-tim-deliver-live-updates-in-production",
+              "quote": "Concrete instance of the architecture question in [[how-should-tim-deliver-live-updates-in-production]]."
+            },
+            {
+              "entry": "Web-only APIs in an app that ships native targets",
+              "kind": "path",
+              "value": "auth.tsx:18,19,29,30,36,37",
+              "quote": ""
+            },
+            {
+              "entry": "Web-only APIs in an app that ships native targets",
+              "kind": "path",
+              "value": "theme.tsx:25,34",
+              "quote": ""
+            },
+            {
+              "entry": "Web-only APIs in an app that ships native targets",
+              "kind": "path",
+              "value": "new-ticket.tsx:51,62",
+              "quote": ""
+            },
+            {
+              "entry": "Web-only APIs in an app that ships native targets",
+              "kind": "path",
+              "value": "DialogFooter.tsx:8-10",
+              "quote": ""
+            },
+            {
+              "entry": "Web-only APIs in an app that ships native targets",
+              "kind": "path",
+              "value": "MoveTicketDialog.tsx:73",
+              "quote": ""
+            },
+            {
+              "entry": "The new-ticket form collects parts the schema cannot store",
+              "kind": "path",
+              "value": "new-ticket.tsx:7-13",
+              "quote": ""
+            },
+            {
+              "entry": "The new-ticket form collects parts the schema cannot store",
+              "kind": "xref",
+              "value": "what-should-the-job-wizard-actually-collect",
+              "quote": "Feeds directly into [[what-should-the-job-wizard-actually-collect]]."
+            },
+            {
+              "entry": "Two competing time-tracking mechanisms in the schema",
+              "kind": "path",
+              "value": "schema.rb:111-121",
+              "quote": ""
+            },
+            {
+              "entry": "Two competing time-tracking mechanisms in the schema",
+              "kind": "path",
+              "value": "schema.rb:90-99",
+              "quote": ""
+            },
+            {
+              "entry": "Two competing time-tracking mechanisms in the schema",
+              "kind": "xref",
+              "value": "should-project-management-and-hour-tracking-live-inside-tim-itself",
+              "quote": "Bears on [[should-project-management-and-hour-tracking-live-inside-tim-itself]]."
+            },
+            {
+              "entry": "gh#4 some text not visible in light mode",
+              "kind": "ghref",
+              "value": "4",
+              "quote": ""
+            },
+            {
+              "entry": "gh#6 move the to-do list into the project tracker",
+              "kind": "ghref",
+              "value": "6",
+              "quote": ""
+            },
+            {
+              "entry": "gh#6 move the to-do list into the project tracker",
+              "kind": "xref",
+              "value": "which-free-project-management-tool-fits-a-one-person-project",
+              "quote": "overlaps [[which-free-project-management-tool-fits-a-one-person-project]]: that entry picks the tool, this one does the migration once a tool is picked."
+            },
+            {
+              "entry": "What should the job wizard actually collect",
+              "kind": "symbol",
+              "value": "job wizard",
+              "quote": ""
+            },
+            {
+              "entry": "TicketCard prints the PO twice",
+              "kind": "path",
+              "value": "TicketCard.tsx:38",
+              "quote": ""
+            },
+            {
+              "entry": "TicketCard prints the PO twice",
+              "kind": "path",
+              "value": "TicketCard.tsx:41",
+              "quote": ""
+            }
+          ]
+        },
+        "raw": "{\n  \"items\": [\n    {\n      \"entry\": \"Job has_many colors but the controller calls job.color\",\n      \"kind\": \"symbol\",\n      \"value\": \"job.color\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Job has_many colors but the controller calls job.color\",\n      \"kind\": \"path\",\n      \"value\": \"job.rb:6\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Job has_many colors but the controller calls job.color\",\n      \"kind\": \"path\",\n      \"value\": \"jobs_controller.rb:18\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"CI has never run because the workflow is not at the repo root\",\n      \"kind\": \"path\",\n      \"value\": \"API/.github/workflows/ci.yml\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"CI has never run because the workflow is not at the repo root\",\n      \"kind\": \"symbol\",\n      \"value\": \"Brakeman\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"CI has never run because the workflow is not at the repo root\",\n      \"kind\": \"symbol\",\n      \"value\": \"RuboCop\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"CI has never run because the workflow is not at the repo root\",\n      \"kind\": \"symbol\",\n      \"value\": \"test job\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"broadcast_update is never called\",\n      \"kind\": \"symbol\",\n      \"value\": \"broadcast_update\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"broadcast_update is never called\",\n      \"kind\": \"path\",\n      \"value\": \"jobs_controller.rb:29-34\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"broadcast_update is never called\",\n      \"kind\": \"xref\",\n      \"value\": \"how-should-tim-deliver-live-updates-in-production\",\n      \"quote\": \"Concrete instance of the architecture question in [[how-should-tim-deliver-live-updates-in-production]].\"\n    },\n    {\n      \"entry\": \"Web-only APIs in an app that ships native targets\",\n      \"kind\": \"path\",\n      \"value\": \"auth.tsx:18,19,29,30,36,37\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Web-only APIs in an app that ships native targets\",\n      \"kind\": \"path\",\n      \"value\": \"theme.tsx:25,34\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Web-only APIs in an app that ships native targets\",\n      \"kind\": \"path\",\n      \"value\": \"new-ticket.tsx:51,62\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Web-only APIs in an app that ships native targets\",\n      \"kind\": \"path\",\n      \"value\": \"DialogFooter.tsx:8-10\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Web-only APIs in an app that ships native targets\",\n      \"kind\": \"path\",\n      \"value\": \"MoveTicketDialog.tsx:73\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"The new-ticket form collects parts the schema cannot store\",\n      \"kind\": \"path\",\n      \"value\": \"new-ticket.tsx:7-13\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"The new-ticket form collects parts the schema cannot store\",\n      \"kind\": \"xref\",\n      \"value\": \"what-should-the-job-wizard-actually-collect\",\n      \"quote\": \"Feeds directly into [[what-should-the-job-wizard-actually-collect]].\"\n    },\n    {\n      \"entry\": \"Two competing time-tracking mechanisms in the schema\",\n      \"kind\": \"path\",\n      \"value\": \"schema.rb:111-121\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Two competing time-tracking mechanisms in the schema\",\n      \"kind\": \"path\",\n      \"value\": \"schema.rb:90-99\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Two competing time-tracking mechanisms in the schema\",\n      \"kind\": \"xref\",\n      \"value\": \"should-project-management-and-hour-tracking-live-inside-tim-itself\",\n      \"quote\": \"Bears on [[should-project-management-and-hour-tracking-live-inside-tim-itself]].\"\n    },\n    {\n      \"entry\": \"gh#4 some text not visible in light mode\",\n      \"kind\": \"ghref\",\n      \"value\": \"4\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"gh#6 move the to-do list into the project tracker\",\n      \"kind\": \"ghref\",\n      \"value\": \"6\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"gh#6 move the to-do list into the project tracker\",\n      \"kind\": \"xref\",\n      \"value\": \"which-free-project-management-tool-fits-a-one-person-project\",\n      \"quote\": \"overlaps [[which-free-project-management-tool-fits-a-one-person-project]]: that entry picks the tool, this one does the migration once a tool is picked.\"\n    },\n    {\n      \"entry\": \"What should the job wizard actually collect\",\n      \"kind\": \"symbol\",\n      \"value\": \"job wizard\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"TicketCard prints the PO twice\",\n      \"kind\": \"path\",\n      \"value\": \"TicketCard.tsx:38\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"TicketCard prints the PO twice\",\n      \"kind\": \"path\",\n      \"value\": \"TicketCard.tsx:41\",\n      \"quote\": \"\"\n    }\n  ]\n}",
+        "note": null,
+        "retries": 0,
+        "usage": {
+          "in_tokens": 1423,
+          "out_tokens": 1494,
+          "wall_s": 38.92,
+          "load_s": 2.58,
+          "eval_s": 33.67
+        }
+      },
+      {
+        "drone": "Gyges",
+        "focus": "every file path, stated dependency, cross-reference and code identifier in these register rows",
+        "ok": true,
+        "data": {
+          "items": [
+            {
+              "entry": "jobs table has no organization_id but the controller scopes on it",
+              "kind": "symbol",
+              "value": "organization_id",
+              "quote": ""
+            },
+            {
+              "entry": "jobs table has no organization_id but the controller scopes on it",
+              "kind": "path",
+              "value": "jobs_controller.rb:5",
+              "quote": ""
+            },
+            {
+              "entry": "jobs table has no organization_id but the controller scopes on it",
+              "kind": "path",
+              "value": "schema.rb:59-71",
+              "quote": ""
+            },
+            {
+              "entry": "jobs table has no organization_id but the controller scopes on it",
+              "kind": "symbol",
+              "value": "broadcast_update",
+              "quote": ""
+            },
+            {
+              "entry": "jobs table has no organization_id but the controller scopes on it",
+              "kind": "xref",
+              "value": "gh#10",
+              "quote": "Not the same as the forgeable-token half of gh#10"
+            },
+            {
+              "entry": "Create ticket creates nothing and reports success",
+              "kind": "path",
+              "value": "new-ticket.tsx:49-64",
+              "quote": ""
+            },
+            {
+              "entry": "Create ticket creates nothing and reports success",
+              "kind": "dependency",
+              "value": "Blocked by the missing create route.",
+              "quote": "Blocked by the missing create route."
+            },
+            {
+              "entry": "Save settings discards every field",
+              "kind": "path",
+              "value": "settings/[userId].tsx:59-64",
+              "quote": ""
+            },
+            {
+              "entry": "Save settings discards every field",
+              "kind": "symbol",
+              "value": "onPress",
+              "quote": ""
+            },
+            {
+              "entry": "A Color belongs to both a customer and a job, both optional",
+              "kind": "path",
+              "value": "color.rb:2-3",
+              "quote": ""
+            },
+            {
+              "entry": "No front-end tests and expo lint is never run",
+              "kind": "path",
+              "value": "WEB/package.json",
+              "quote": ""
+            },
+            {
+              "entry": "The menu always opens user 1's settings",
+              "kind": "path",
+              "value": "DropdownMenu.tsx:38",
+              "quote": ""
+            },
+            {
+              "entry": "MoveTicketDialog never clears the note between tickets",
+              "kind": "path",
+              "value": "MoveTicketDialog.tsx:33-39",
+              "quote": ""
+            },
+            {
+              "entry": "Which free project management tool fits a one-person project",
+              "kind": "symbol",
+              "value": "TO_DO.md",
+              "quote": "Also arguably already answered \u2014 issues and TO_DO.md are both live in this repo."
+            }
+          ]
+        },
+        "raw": "{\n  \"items\": [\n    {\n      \"entry\": \"jobs table has no organization_id but the controller scopes on it\",\n      \"kind\": \"symbol\",\n      \"value\": \"organization_id\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"jobs table has no organization_id but the controller scopes on it\",\n      \"kind\": \"path\",\n      \"value\": \"jobs_controller.rb:5\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"jobs table has no organization_id but the controller scopes on it\",\n      \"kind\": \"path\",\n      \"value\": \"schema.rb:59-71\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"jobs table has no organization_id but the controller scopes on it\",\n      \"kind\": \"symbol\",\n      \"value\": \"broadcast_update\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"jobs table has no organization_id but the controller scopes on it\",\n      \"kind\": \"xref\",\n      \"value\": \"gh#10\",\n      \"quote\": \"Not the same as the forgeable-token half of gh#10\"\n    },\n    {\n      \"entry\": \"Create ticket creates nothing and reports success\",\n      \"kind\": \"path\",\n      \"value\": \"new-ticket.tsx:49-64\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Create ticket creates nothing and reports success\",\n      \"kind\": \"dependency\",\n      \"value\": \"Blocked by the missing create route.\",\n      \"quote\": \"Blocked by the missing create route.\"\n    },\n    {\n      \"entry\": \"Save settings discards every field\",\n      \"kind\": \"path\",\n      \"value\": \"settings/[userId].tsx:59-64\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Save settings discards every field\",\n      \"kind\": \"symbol\",\n      \"value\": \"onPress\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"A Color belongs to both a customer and a job, both optional\",\n      \"kind\": \"path\",\n      \"value\": \"color.rb:2-3\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"No front-end tests and expo lint is never run\",\n      \"kind\": \"path\",\n      \"value\": \"WEB/package.json\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"The menu always opens user 1's settings\",\n      \"kind\": \"path\",\n      \"value\": \"DropdownMenu.tsx:38\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"MoveTicketDialog never clears the note between tickets\",\n      \"kind\": \"path\",\n      \"value\": \"MoveTicketDialog.tsx:33-39\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Which free project management tool fits a one-person project\",\n      \"kind\": \"symbol\",\n      \"value\": \"TO_DO.md\",\n      \"quote\": \"Also arguably already answered \u2014 issues and TO_DO.md are both live in this repo.\"\n    }\n  ]\n}",
+        "note": null,
+        "retries": 0,
+        "usage": {
+          "in_tokens": 1266,
+          "out_tokens": 767,
+          "wall_s": 23.73,
+          "load_s": 2.89,
+          "eval_s": 18.09
+        }
+      },
+      {
+        "drone": "Brontes",
+        "focus": "every file path, stated dependency, cross-reference and code identifier in these register rows",
+        "ok": true,
+        "data": {
+          "items": [
+            {
+              "entry": "jobs_controller renders notes and description, neither is a column",
+              "kind": "path",
+              "value": "jobs_controller.rb:17,19",
+              "quote": "jobs_controller.rb:17,19 render job.notes and job.description; the jobs table has neither. schedule.tsx:45,47 maps both into every ticket."
+            },
+            {
+              "entry": "No route creates or updates a job",
+              "kind": "path",
+              "value": "routes.rb:11-15",
+              "quote": "routes.rb:11-15 declares only POST /api/sessions, DELETE /api/session, GET /api/jobs. The new-ticket form and the move-ticket dialog have no endpoint to call. Blocks the two 'not persisted' entries below."
+            },
+            {
+              "entry": "Moving a ticket is not persisted",
+              "kind": "path",
+              "value": "schedule.tsx:167-180",
+              "quote": "schedule.tsx:167-180 updates local state only; a refresh reverts it. Different from the existing 'move dialog not styled' to-do, which is appearance."
+            },
+            {
+              "entry": "Sections are matched against area.name with nothing keeping them in sync",
+              "kind": "path",
+              "value": "schedule.tsx:150",
+              "quote": "schedule.tsx:150 filters ticket.location === section; location is area.name straight from the DB (jobs_controller.rb:16). Any area not named exactly one of the nine strings drops its tickets silently. Code vs database, where the two entries above are code vs code. Decides [[should-the-prep-job-section-be-split-into-prep-and-wash]]."
+            },
+            {
+              "entry": "Subscription failures are invisible and the socket never reconnects",
+              "kind": "path",
+              "value": "schedule.tsx:71-83",
+              "quote": "schedule.tsx:71-83 handles only ping and job_updated, ignoring confirm_subscription and reject_subscription; onclose at :85 only logs. Given the nil-user rejection, a rejected subscription looks exactly like an idle connection."
+            },
+            {
+              "entry": "authFetch is rebuilt every render and sits in the effect deps",
+              "kind": "path",
+              "value": "auth.tsx:40",
+              "quote": "auth.tsx:40 is not memoised and schedule.tsx:54 depends on it, so jobs refetch whenever AuthProvider re-renders rather than when the token changes."
+            },
+            {
+              "entry": "Section list is duplicated verbatim in two files",
+              "kind": "path",
+              "value": "schedule.tsx:13-23",
+              "quote": "schedule.tsx:13-23 and MoveTicketDialog.tsx:20-30 hold the same nine strings."
+            },
+            {
+              "entry": "Part ids collide because addPart uses prev.length + 1",
+              "kind": "path",
+              "value": "new-ticket.tsx:36",
+              "quote": "new-ticket.tsx:36. Remove part 2 of 3 then add one and two parts share id 3 -- which is the React key."
+            },
+            {
+              "entry": "Dead duplicate CORS config in initializers/cors.rb",
+              "kind": "path",
+              "value": "initializers/cors.rb",
+              "quote": "cors.rb is commented out end to end while the live rule sits in application.rb:33-38. Two places to look, one inert. The origins '*' value itself is gh#10; this is the duplication."
+            },
+            {
+              "entry": "Task is the only model with no validations",
+              "kind": "path",
+              "value": "API/app/models/task.rb",
+              "quote": "API/app/models/task.rb -- no validates line."
+            },
+            {
+              "entry": "Kamal deploy image is still the placeholder your-user/api",
+              "kind": "path",
+              "value": "deploy.yml:5",
+              "quote": "deploy.yml:5. Harmless until someone runs kamal deploy."
+            },
+            {
+              "entry": "jobs_controller renders notes and description, neither is a column",
+              "kind": "symbol",
+              "value": "jobs_controller",
+              "quote": ""
+            },
+            {
+              "entry": "jobs_controller renders notes and description, neither is a column",
+              "kind": "symbol",
+              "value": "job.notes",
+              "quote": ""
+            },
+            {
+              "entry": "jobs_controller renders notes and description, neither is a column",
+              "kind": "symbol",
+              "value": "job.description",
+              "quote": ""
+            },
+            {
+              "entry": "jobs_controller renders notes and description, neither is a column",
+              "kind": "symbol",
+              "value": "schedule.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "No route creates or updates a job",
+              "kind": "symbol",
+              "value": "routes.rb",
+              "quote": ""
+            },
+            {
+              "entry": "No route creates or updates a job",
+              "kind": "symbol",
+              "value": "POST /api/sessions",
+              "quote": ""
+            },
+            {
+              "entry": "No route creates or updates a job",
+              "kind": "symbol",
+              "value": "DELETE /api/session",
+              "quote": ""
+            },
+            {
+              "entry": "No route creates or updates a job",
+              "kind": "symbol",
+              "value": "GET /api/jobs",
+              "quote": ""
+            },
+            {
+              "entry": "Moving a ticket is not persisted",
+              "kind": "symbol",
+              "value": "schedule.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "Moving a ticket is not persisted",
+              "kind": "symbol",
+              "value": "move dialog not styled",
+              "quote": ""
+            },
+            {
+              "entry": "Sections are matched against area.name with nothing keeping them in sync",
+              "kind": "symbol",
+              "value": "schedule.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "Sections are matched against area.name with nothing keeping them in sync",
+              "kind": "symbol",
+              "value": "ticket.location",
+              "quote": ""
+            },
+            {
+              "entry": "Sections are matched against area.name with nothing keeping them in sync",
+              "kind": "symbol",
+              "value": "area.name",
+              "quote": ""
+            },
+            {
+              "entry": "Sections are matched against area.name with nothing keeping them in sync",
+              "kind": "symbol",
+              "value": "jobs_controller.rb",
+              "quote": ""
+            },
+            {
+              "entry": "Subscription failures are invisible and the socket never reconnects",
+              "kind": "symbol",
+              "value": "schedule.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "Subscription failures are invisible and the socket never reconnects",
+              "kind": "symbol",
+              "value": "job_updated",
+              "quote": ""
+            },
+            {
+              "entry": "Subscription failures are invisible and the socket never reconnects",
+              "kind": "symbol",
+              "value": "confirm_subscription",
+              "quote": ""
+            },
+            {
+              "entry": "Subscription failures are invisible and the socket never reconnects",
+              "kind": "symbol",
+              "value": "reject_subscription",
+              "quote": ""
+            },
+            {
+              "entry": "Subscription failures are invisible and the socket never reconnects",
+              "kind": "symbol",
+              "value": "onclose",
+              "quote": ""
+            },
+            {
+              "entry": "authFetch is rebuilt every render and sits in the effect deps",
+              "kind": "symbol",
+              "value": "auth.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "authFetch is rebuilt every render and sits in the effect deps",
+              "kind": "symbol",
+              "value": "schedule.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "authFetch is rebuilt every render and sits in the effect deps",
+              "kind": "symbol",
+              "value": "jobs",
+              "quote": ""
+            },
+            {
+              "entry": "Section list is duplicated verbatim in two files",
+              "kind": "symbol",
+              "value": "schedule.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "Section list is duplicated verbatim in two files",
+              "kind": "symbol",
+              "value": "MoveTicketDialog.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "Part ids collide because addPart uses prev.length + 1",
+              "kind": "symbol",
+              "value": "new-ticket.tsx",
+              "quote": ""
+            },
+            {
+              "entry": "Part ids collide because addPart uses prev.length + 1",
+              "kind": "symbol",
+              "value": "addPart",
+              "quote": ""
+            },
+            {
+              "entry": "Dead duplicate CORS config in initializers/cors.rb",
+              "kind": "symbol",
+              "value": "cors.rb",
+              "quote": ""
+            },
+            {
+              "entry": "Dead duplicate CORS config in initializers/cors.rb",
+              "kind": "symbol",
+              "value": "application.rb",
+              "quote": ""
+            },
+            {
+              "entry": "Dead duplicate CORS config in initializers/cors.rb",
+              "kind": "symbol",
+              "value": "origins",
+              "quote": ""
+            },
+            {
+              "entry": "Task is the only model with no validations",
+              "kind": "symbol",
+              "value": "task.rb",
+              "quote": ""
+            },
+            {
+              "entry": "Kamal deploy image is still the placeholder your-user/api",
+              "kind": "symbol",
+              "value": "deploy.yml",
+              "quote": ""
+            }
+          ]
+        },
+        "raw": "{\n  \"items\": [\n    {\n      \"entry\": \"jobs_controller renders notes and description, neither is a column\",\n      \"kind\": \"path\",\n      \"value\": \"jobs_controller.rb:17,19\",\n      \"quote\": \"jobs_controller.rb:17,19 render job.notes and job.description; the jobs table has neither. schedule.tsx:45,47 maps both into every ticket.\"\n    },\n    {\n      \"entry\": \"No route creates or updates a job\",\n      \"kind\": \"path\",\n      \"value\": \"routes.rb:11-15\",\n      \"quote\": \"routes.rb:11-15 declares only POST /api/sessions, DELETE /api/session, GET /api/jobs. The new-ticket form and the move-ticket dialog have no endpoint to call. Blocks the two 'not persisted' entries below.\"\n    },\n    {\n      \"entry\": \"Moving a ticket is not persisted\",\n      \"kind\": \"path\",\n      \"value\": \"schedule.tsx:167-180\",\n      \"quote\": \"schedule.tsx:167-180 updates local state only; a refresh reverts it. Different from the existing 'move dialog not styled' to-do, which is appearance.\"\n    },\n    {\n      \"entry\": \"Sections are matched against area.name with nothing keeping them in sync\",\n      \"kind\": \"path\",\n      \"value\": \"schedule.tsx:150\",\n      \"quote\": \"schedule.tsx:150 filters ticket.location === section; location is area.name straight from the DB (jobs_controller.rb:16). Any area not named exactly one of the nine strings drops its tickets silently. Code vs database, where the two entries above are code vs code. Decides [[should-the-prep-job-section-be-split-into-prep-and-wash]].\"\n    },\n    {\n      \"entry\": \"Subscription failures are invisible and the socket never reconnects\",\n      \"kind\": \"path\",\n      \"value\": \"schedule.tsx:71-83\",\n      \"quote\": \"schedule.tsx:71-83 handles only ping and job_updated, ignoring confirm_subscription and reject_subscription; onclose at :85 only logs. Given the nil-user rejection, a rejected subscription looks exactly like an idle connection.\"\n    },\n    {\n      \"entry\": \"authFetch is rebuilt every render and sits in the effect deps\",\n      \"kind\": \"path\",\n      \"value\": \"auth.tsx:40\",\n      \"quote\": \"auth.tsx:40 is not memoised and schedule.tsx:54 depends on it, so jobs refetch whenever AuthProvider re-renders rather than when the token changes.\"\n    },\n    {\n      \"entry\": \"Section list is duplicated verbatim in two files\",\n      \"kind\": \"path\",\n      \"value\": \"schedule.tsx:13-23\",\n      \"quote\": \"schedule.tsx:13-23 and MoveTicketDialog.tsx:20-30 hold the same nine strings.\"\n    },\n    {\n      \"entry\": \"Part ids collide because addPart uses prev.length + 1\",\n      \"kind\": \"path\",\n      \"value\": \"new-ticket.tsx:36\",\n      \"quote\": \"new-ticket.tsx:36. Remove part 2 of 3 then add one and two parts share id 3 -- which is the React key.\"\n    },\n    {\n      \"entry\": \"Dead duplicate CORS config in initializers/cors.rb\",\n      \"kind\": \"path\",\n      \"value\": \"initializers/cors.rb\",\n      \"quote\": \"cors.rb is commented out end to end while the live rule sits in application.rb:33-38. Two places to look, one inert. The origins '*' value itself is gh#10; this is the duplication.\"\n    },\n    {\n      \"entry\": \"Task is the only model with no validations\",\n      \"kind\": \"path\",\n      \"value\": \"API/app/models/task.rb\",\n      \"quote\": \"API/app/models/task.rb -- no validates line.\"\n    },\n    {\n      \"entry\": \"Kamal deploy image is still the placeholder your-user/api\",\n      \"kind\": \"path\",\n      \"value\": \"deploy.yml:5\",\n      \"quote\": \"deploy.yml:5. Harmless until someone runs kamal deploy.\"\n    },\n    {\n      \"entry\": \"jobs_controller renders notes and description, neither is a column\",\n      \"kind\": \"symbol\",\n      \"value\": \"jobs_controller\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"jobs_controller renders notes and description, neither is a column\",\n      \"kind\": \"symbol\",\n      \"value\": \"job.notes\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"jobs_controller renders notes and description, neither is a column\",\n      \"kind\": \"symbol\",\n      \"value\": \"job.description\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"jobs_controller renders notes and description, neither is a column\",\n      \"kind\": \"symbol\",\n      \"value\": \"schedule.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"No route creates or updates a job\",\n      \"kind\": \"symbol\",\n      \"value\": \"routes.rb\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"No route creates or updates a job\",\n      \"kind\": \"symbol\",\n      \"value\": \"POST /api/sessions\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"No route creates or updates a job\",\n      \"kind\": \"symbol\",\n      \"value\": \"DELETE /api/session\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"No route creates or updates a job\",\n      \"kind\": \"symbol\",\n      \"value\": \"GET /api/jobs\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Moving a ticket is not persisted\",\n      \"kind\": \"symbol\",\n      \"value\": \"schedule.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Moving a ticket is not persisted\",\n      \"kind\": \"symbol\",\n      \"value\": \"move dialog not styled\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Sections are matched against area.name with nothing keeping them in sync\",\n      \"kind\": \"symbol\",\n      \"value\": \"schedule.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Sections are matched against area.name with nothing keeping them in sync\",\n      \"kind\": \"symbol\",\n      \"value\": \"ticket.location\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Sections are matched against area.name with nothing keeping them in sync\",\n      \"kind\": \"symbol\",\n      \"value\": \"area.name\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Sections are matched against area.name with nothing keeping them in sync\",\n      \"kind\": \"symbol\",\n      \"value\": \"jobs_controller.rb\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Subscription failures are invisible and the socket never reconnects\",\n      \"kind\": \"symbol\",\n      \"value\": \"schedule.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Subscription failures are invisible and the socket never reconnects\",\n      \"kind\": \"symbol\",\n      \"value\": \"job_updated\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Subscription failures are invisible and the socket never reconnects\",\n      \"kind\": \"symbol\",\n      \"value\": \"confirm_subscription\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Subscription failures are invisible and the socket never reconnects\",\n      \"kind\": \"symbol\",\n      \"value\": \"reject_subscription\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Subscription failures are invisible and the socket never reconnects\",\n      \"kind\": \"symbol\",\n      \"value\": \"onclose\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"authFetch is rebuilt every render and sits in the effect deps\",\n      \"kind\": \"symbol\",\n      \"value\": \"auth.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"authFetch is rebuilt every render and sits in the effect deps\",\n      \"kind\": \"symbol\",\n      \"value\": \"schedule.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"authFetch is rebuilt every render and sits in the effect deps\",\n      \"kind\": \"symbol\",\n      \"value\": \"jobs\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Section list is duplicated verbatim in two files\",\n      \"kind\": \"symbol\",\n      \"value\": \"schedule.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Section list is duplicated verbatim in two files\",\n      \"kind\": \"symbol\",\n      \"value\": \"MoveTicketDialog.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Part ids collide because addPart uses prev.length + 1\",\n      \"kind\": \"symbol\",\n      \"value\": \"new-ticket.tsx\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Part ids collide because addPart uses prev.length + 1\",\n      \"kind\": \"symbol\",\n      \"value\": \"addPart\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Dead duplicate CORS config in initializers/cors.rb\",\n      \"kind\": \"symbol\",\n      \"value\": \"cors.rb\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Dead duplicate CORS config in initializers/cors.rb\",\n      \"kind\": \"symbol\",\n      \"value\": \"application.rb\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Dead duplicate CORS config in initializers/cors.rb\",\n      \"kind\": \"symbol\",\n      \"value\": \"origins\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Task is the only model with no validations\",\n      \"kind\": \"symbol\",\n      \"value\": \"task.rb\",\n      \"quote\": \"\"\n    },\n    {\n      \"entry\": \"Kamal deploy image is still the placeholder your-user/api\",\n      \"kind\": \"symbol\",\n      \"value\": \"deploy.yml\",\n      \"quote\": \"\"\n    }\n  ]\n}",
+        "note": null,
+        "retries": 0,
+        "usage": {
+          "in_tokens": 1262,
+          "out_tokens": 2518,
+          "wall_s": 55.65,
+          "load_s": 2.88,
+          "eval_s": 51.71
+        }
+      }
+    ],
+    "tartarus": {
+      "in_tokens": 5417,
+      "out_tokens": 6808,
+      "drone_seconds": 166.63,
+      "eval_seconds": 147.06,
+      "wave_wall_s": 55.65
+    },
+    "muster": {
+      "hands": 4,
+      "num_ctx": 8192,
+      "footprint_bytes": 3356365945,
+      "measured": true,
+      "budget_bytes": 9792525434,
+      "fits": true,
+      "basis": "vram",
+      "concurrency": {
+        "parallel": true,
+        "slots": 4,
+        "ratio": null,
+        "source": "ollama server log",
+        "note": null
+      },
+      "notes": []
+    },
+    "claude": {
+      "turns": 44,
+      "subagent_turns": 32,
+      "input_tokens": 152,
+      "output_tokens": 53477,
+      "thinking_tokens": 22781,
+      "cache_write_tokens": 644160,
+      "cache_read_tokens": 8049223,
+      "web_search_requests": 0,
+      "web_fetch_requests": 0,
+      "models": {
+        "claude-opus-5": 44,
+        "claude-sonnet-5": 32
+      },
+      "session_id": "a126aabc-a6b7-439f-865a-3e33c1c95a41",
+      "first_wave": false
+    }
+  }
+}

--- a/dossiers/tim-issue-milestones/.waves/wave-02.json
+++ b/dossiers/tim-issue-milestones/.waves/wave-02.json
@@ -1,0 +1,34 @@
+{
+  "label": "Synthesis and drafting",
+  "question": null,
+  "ran_at": "2026-08-20 07:59",
+  "run": {
+    "ok": true,
+    "claude_only": true,
+    "model": null,
+    "wave_wall_s": 0.0,
+    "results": [],
+    "tartarus": {
+      "in_tokens": 0,
+      "out_tokens": 0,
+      "drone_seconds": 0.0,
+      "wave_wall_s": 0.0
+    },
+    "claude": {
+      "turns": 21,
+      "subagent_turns": 0,
+      "input_tokens": 42,
+      "output_tokens": 25338,
+      "thinking_tokens": 11272,
+      "cache_write_tokens": 30258,
+      "cache_read_tokens": 3880000,
+      "web_search_requests": 0,
+      "web_fetch_requests": 0,
+      "models": {
+        "claude-opus-5": 21
+      },
+      "session_id": "a126aabc-a6b7-439f-865a-3e33c1c95a41",
+      "first_wave": false
+    }
+  }
+}

--- a/dossiers/tim-issue-milestones/report.md
+++ b/dossiers/tim-issue-milestones/report.md
@@ -1,0 +1,225 @@
+# TIM issue milestones
+
+**Question:** In what order should TIM's 46 open entries be worked, grouped into
+milestones that are each independently shippable and independently verifiable?
+
+**Answer:** Ten milestones, in a chain of five (M0 → M4) that must run in order
+because each is unobservable until the one before it lands, plus five (M5 → M9)
+that are independent and can be picked up at any time. The first milestone is
+not a bug fix — it is making the build able to tell you when something is
+broken. · **Confidence:** High on the ordering, which rests on the dependency
+and co-location evidence below. Medium on the milestone *sizes*, which rest on
+reading the code rather than on having done the work.
+
+## Why this matters
+
+There are 46 open entries and no order to them. Worked by score alone, the top
+of the list is four entries that all live in the same 30-line controller and one
+that cannot be verified at all, because nothing in this repository currently
+runs a check. The risk is not picking the wrong issue; it is spending a weekend
+fixing three real bugs and having no way to know whether any of them worked.
+
+Two facts make the ordering non-obvious, and both were established rather than
+assumed:
+
+- **Fixing issue #10 does not make the app work.** Its own write-up says fixing
+  it unblocks most of the sweep, and that is true — but `GET /api/jobs` still
+  returns 500 afterwards, because the controller reads three things that do not
+  exist in the schema. Routing and the three column bugs have to ship together
+  or the milestone has no green state to end on.
+- **The hottest file is not the one with the worst bugs.**
+  `WEB/app/(tabs)/schedule.tsx` is touched by 8 of the 46 entries — more than
+  any other file — but they belong to five different milestones.
+
+## What we found
+
+### The dependency chain
+
+Four dependencies are stated outright in the entries themselves (Wave 1,
+`kind='dependency'`):
+
+| Entry | States |
+| --- | --- |
+| gh#10 | "Fixing it unblocks most of the sweep entries" |
+| Create ticket creates nothing | "Blocked by the missing create route" |
+| No route creates or updates a job | "Blocks the two 'not persisted' entries" |
+| Tests cover models only | "would have caught all three blocking entries" |
+
+Three more are cross-references between entries (`kind='xref'`):
+`broadcast_update is never called` → the live-updates architecture question;
+`the new-ticket form collects parts the schema cannot store` → the job wizard
+question; `two competing time-tracking mechanisms` → the project-management
+scope question. In each case the question has to be answered before the code
+entry can be closed, because the code entry's fix depends on the answer.
+
+**There is no cycle.** Every stated dependency points from a later concern to an
+earlier one, so a total order exists.
+
+### The co-location clusters
+
+Computed deterministically over all 46 notes — file paths extracted by regex,
+grouped and counted in Python rather than by a drone, because counting is where
+drones quietly go wrong:
+
+| File | Entries | Scores |
+| --- | ---: | --- |
+| `schedule.tsx` | 8 | 10, 10, 8, 7, 6, 5, 5, 4 |
+| `jobs_controller.rb` | 5 | 10, 10, 10, 8, 7 |
+| `auth.tsx` | 4 | 10, 8, 5, 3 |
+| `new-ticket.tsx` | 4 | 9, 8, 7, 4 |
+| `schema.rb` | 3 | 10, 7, 6 |
+| `MoveTicketDialog.tsx` | 3 | 8, 5, 3 |
+| `routes.rb`, `connection.rb`, `DropdownMenu.tsx` | 2 each | — |
+
+Nine entries cite no file at all. Those are decisions, not edits, and three of
+them gate code entries — which is why they appear at the *head* of a milestone
+rather than as work items inside it.
+
+### The verification gap
+
+Every milestone below ends in an observable check. Today, none of those checks
+can run:
+
+- `API/.github/workflows/ci.yml` is not at the repository root, so GitHub Actions
+  has never executed it — Brakeman, RuboCop and the test job have all never run.
+- The 35 existing tests are model tests. `API/test/controllers/` and
+  `API/test/integration/` contain only a `.keep`; `API/test/channels/` does not
+  exist.
+- `WEB/package.json` has no `test` script.
+
+This is why M0 exists and why it comes first.
+
+## The answer
+
+### The chain — these must run in order
+
+**M0 · Make failure visible.** Move `API/.github/workflows/` to the repository
+root; add one request test for `GET /api/jobs`; add a `test` script to
+`WEB/package.json`.
+*Entries: CI has never run (9), Tests cover models only (8), No front-end tests (5).*
+**Done when:** a push produces a CI run, and that run is **red** on `/api/jobs`.
+A red run is the success condition — it is the first time this repository has
+been able to state its own condition.
+**Why first:** it depends on nothing, it is the cheapest item in the jar, and
+every milestone after it borrows its check.
+
+**M1 · `GET /api/jobs` returns 200.** The routing half of gh#10 plus the three
+blockers, which all live in the same file.
+*Entries: gh#10 routing half (10), jobs has no organization_id (10), job.color vs has_many :colors (10), notes/description are not columns (10), session route paths disagree (4).*
+**Done when:** M0's request test goes green.
+**Contains two decisions, not just fixes:** does `organization_id` go onto
+`jobs`, or does the tenant scope reach through `customer`? And do `notes` and
+`description` become columns, or leave the payload? Both change the migration.
+
+**M2 · A user can log in.** The base-URL half of gh#10, a login screen, and real
+tokens.
+*Entries: gh#10 base-URL half (10), nothing ever calls login (10), authFetch rebuilt every render (5), default auth context returns empty 200 (3).*
+**Done when:** you log in in a browser and the schedule lists real jobs.
+**Do not skip the token work here.** `DOCS/ISSUE_web_api_wiring.md` is explicit
+that fixing the routing makes a forgeable scheme *reachable* — the token is the
+user id, and CORS is `origins '*'`. M1 shipped anywhere public without M2 is the
+one genuinely dangerous ordering in this plan.
+
+**M3 · Writes persist.** The create/update routes and the three screens that
+pretend to save.
+*Entries: no route creates or updates a job (9), create ticket creates nothing (9), moving a ticket is not persisted (8), save settings discards every field (7).*
+**Gated by a decision:** *what should the job wizard collect* (3) and *the
+new-ticket form collects parts the schema cannot store* (7) must be answered
+first — the create endpoint's shape depends on whether "parts" become a table.
+**Done when:** create a ticket, refresh, it is still there; move it, refresh, it
+stayed moved.
+
+**M4 · Live updates actually update.**
+*Entries: how should TIM deliver live updates (8) — the architecture decision, first; broadcast_update is never called (8); Action Cable does not reject a tokenless connection (8); subscription failures are invisible (6); bare rescue masks errors (5); plus the Action Cable origin check from gh#10's write-up.*
+**Done when:** two browsers open, move a ticket in one, it moves in the other.
+**Why last in the chain:** there is nothing to broadcast until M3 exists.
+
+### The independents — any time, in any order
+
+**M5 · One section list instead of three.** Decide *prep vs prep/wash* (2)
+first, then: sections matched against `area.name` with nothing keeping them in
+sync (7), the list duplicated verbatim in two files (5), and `Ticket.location`
+contradicting both (5). **Done when:** renaming an area in the database cannot
+silently empty a column.
+
+**M6 · Decide web-only or native.** *Web-only APIs in an app that ships native
+targets* (8) is one entry but two different jobs depending on the answer: if TIM
+is web-only, most of it closes by removing the native targets; if not, four
+separate call sites need replacing. **Done when:** either `expo start --android`
+boots, or the native targets are gone from `app.json`.
+
+**M7 · Data-model decisions.** Soft deletes never applied (7), two competing
+time-tracking mechanisms (6), colour belongs to both customer and job (5),
+should project management live inside TIM (6). None blocks the chain; all get
+more expensive with every query written against the current shape.
+
+**M8 · Cleanups.** Eleven entries, scores 2–6, no dependencies, no decisions:
+ticket detail shows fabricated data (6), gh#4 light-mode text (5), part id
+collisions (4), menu always opens user 1 (4), PrimeReact pinned light (4), gh#5
+theme toggle (3), dialog note not cleared (3), dead CORS config (3), Task has no
+validations (3), TicketCard prints PO twice (2), Kamal placeholder (2).
+
+**M9 · Project hygiene.** Pick a tracker (3), migrate the to-do list (gh#6, 3),
+contributor launch instructions (4), audit print template format (5).
+
+### Where the rule does not cleanly hold
+
+The decision rule required each milestone to be closed under co-location. Two
+milestones break that, and both are deliberate:
+
+- **`jobs_controller.rb` is visited twice** — four entries in M1, and
+  `broadcast_update` in M4. Moving it into M1 would satisfy the rule but produce
+  an unverifiable change, since nothing can broadcast until M3. The second visit
+  is cheap because the method is a standalone block at lines 29–34, disjoint
+  from the `index` action at 4–26.
+- **`schedule.tsx` is visited five times** — M2, M3, M4, M5, M8. This is the real
+  cost of the plan. It is tolerable only because the entries occupy disjoint
+  regions of the file: lines 35–54 (fetch and auth), 56–88 (the socket), 13–23
+  with 147–153 (sections), 167–180 (the move handler), and line 6 (the
+  PrimeReact import). No two milestones edit the same lines.
+
+## What would change this
+
+- **If issue #10 is resolved by flattening the routes rather than namespacing the
+  controllers**, M1 shrinks but leaves no room for `/api/v2`. The choice is
+  recorded as undecided in `DOCS/ISSUE_web_api_wiring.md` and is the user's, not
+  a fact to be researched.
+- **If TIM is web-only**, M6 nearly vanishes and the score-8 native entry drops
+  to a deletion.
+- **If "parts" become a real table**, M3 grows a migration and should probably
+  split into M3a (routes and persistence for what already exists) and M3b (parts).
+- **If the deployment target is ever public before M2**, the ordering changes
+  from a convenience to a security requirement.
+
+## Options and trade-offs
+
+The one real choice in the sequencing is **where M0 goes**.
+
+- **M0 first (recommended).** Costs a few hours before a single bug is fixed.
+  Buys a red/green signal that every later milestone reuses. Forecloses nothing.
+- **M0 skipped, start at M1.** Buys the satisfaction of fixing the worst bug
+  first. Costs the ability to know it worked — and the three M1 blockers are
+  exactly the class of bug (a missing column, a wrong association, two absent
+  attributes) that a single request test catches instantly and manual clicking
+  does not. Given that this repository already shipped all three undetected,
+  this option has been tried.
+
+## What we do not know yet
+
+- **Which side of gh#10 moves** — namespacing the controllers or flattening the
+  routes. Not researched, because it is not researchable: the write-up presents
+  it as an open decision for the operator, and both options are viable. It
+  changes M1's size, not its position.
+- **Whether TIM ships native.** Same character — a product decision, not a fact.
+  It is the only thing standing between M6 being an afternoon and a week.
+- **Actual effort per milestone.** Sizes here come from reading the code, not
+  from having done the work. The ordering does not depend on them; the
+  scheduling does.
+- Not a gap, but worth stating: **no milestone here has been executed**, so the
+  claim that each ends in an observable check is a claim about the checks, not a
+  report of having watched them pass.
+
+## Sources
+
+See `research.md` for the full source list, the drone roster and the Tartarus
+ledger.

--- a/dossiers/tim-issue-milestones/research.md
+++ b/dossiers/tim-issue-milestones/research.md
@@ -1,0 +1,169 @@
+# Research Log -- TIM issue milestones
+
+**Subject:** TIM issue milestones
+**Started:** 2026-08-20
+**Status:** complete
+**Verdict:** Ten milestones — a chain of five (M0-M4) fixed by dependency, plus five independents. M0 is the CI/test harness, not a bug fix.
+
+## Sources
+
+| # | Source | URL | Retrieved | Digested by |
+| --- | --- | --- | --- | --- |
+| 1 | The pithos register, TIM jar — all 46 entries with notes, scores and cross-references | `~/pithos/TIM/ideas.md` | 2026-08-20 | Cottus, Briareus, Gyges, Brontes |
+| 2 | The same jar as structured data, for deterministic path extraction | `~/pithos/TIM/ideas.json` | 2026-08-20 | Python (not a drone — see below) |
+| 3 | The code sweep the entries were derived from | `DOCS/TO_DO.md`, "Code Issues Found" | 2026-08-20 | verified against source in the prior session |
+| 4 | The existing write-up of issue #10, including its "Decide this first" section | `DOCS/ISSUE_web_api_wiring.md` | 2026-08-20 | read directly |
+| 5 | Repository source — controllers, models, schema, screens, config, CI workflow | the working tree | 2026-08-20 | read directly, and by drones in the prior session's waves |
+
+**A note on what the drones were and were not asked.** They extracted the
+*stated* relationships — file paths, dependency phrases, `[[xref]]` links, issue
+references, distinction sentences. They were not asked which entries should be
+grouped, what order the milestones go in, or whether a milestone is well-formed.
+Those are judgements and they are Claude's, made against the decision rule
+recorded below.
+
+The file co-location counts in the report were **not** produced by a drone. They
+come from a regex over source 2, grouped and counted in Python, because a
+miscount there would silently reshape the milestones and a drone cannot be
+checked cheaply on arithmetic.
+
+## Research waves
+
+## The frame (written before any research)
+
+**The question.** In what order should TIM's 46 open entries be worked, grouped
+into milestones that are each independently shippable and independently
+verifiable?
+
+**What decides it.** Four things, and nothing else:
+
+1. **Dependency.** Which entries cannot even be *observed* until another is
+   fixed. An entry whose symptom is masked by an earlier bug cannot be verified
+   as done, so it cannot close in an earlier milestone.
+2. **Co-location.** Which entries touch the same file, method or table. Splitting
+   those across milestones means editing the same lines twice and re-testing the
+   same path twice.
+3. **Verifiability.** Whether the milestone ends in a check a person can actually
+   run and watch pass or fail. This is a hard requirement, not a nicety --
+   several entries in the jar exist precisely because nothing ever checked them.
+4. **Shared root cause.** Which entries are one decision expressed several times.
+   Fixing those individually produces three inconsistent half-answers.
+
+**The decision rule.** A proposed milestone is *actionable* if and only if all
+four hold:
+
+- **(a) Closed under dependency** -- no entry in it depends on an entry in a
+  later milestone.
+- **(b) Ends in an observable check** -- a named command, request or screen
+  interaction whose result is unambiguous.
+- **(c) Closed under co-location and root cause** -- entries touching the same
+  file or resolving the same decision are inside it, not split.
+- **(d) Sized for a side project** -- completable in roughly one sitting to one
+  week of part-time work, not an open-ended programme.
+
+A sequence is *actionable* if every milestone in it is actionable and the
+milestones are totally ordered by (a).
+
+**What would mean the answer is "no useful sequence exists":** if the dependency
+graph contains a cycle among high-score entries, or if condition (b) cannot be
+met for the earliest milestone -- i.e. there is no way to observe success at the
+start -- then the honest answer is that a prerequisite piece of work has to come
+before any milestone plan, and I will say that instead of inventing an order.
+
+
+### Wave 1 — what it yielded
+
+Confirmed four dependencies stated outright in the entries (gh#10 unblocking the
+sweep; the create route blocking both "not persisted" entries; the missing
+request test having been able to catch all three blockers) and three `[[xref]]`
+links from code entries to the decision questions that gate them. Critically, it
+established that **the stated dependency graph contains no cycle** — every arrow
+points from a later concern to an earlier one — which is what made a total
+ordering possible rather than a judgement call.
+
+**What it failed to establish.** The drones surface only *stated* relationships.
+Two dependencies in the final plan are not written in any entry and were derived
+by reading code: that M1's four entries must ship together (routing alone leaves
+`/api/jobs` returning 500, because the three column bugs are independent of it),
+and that M4 cannot precede M3 (there is nothing to broadcast until writes
+exist). Both are recorded in the report as inference, not as extracted fact.
+
+**Why no second wave.** The two remaining unknowns — which side of gh#10 moves,
+and whether TIM ships native — are operator decisions, not facts in any source.
+A wave aimed at them would return nothing, and saying so is more useful than
+running it. Neither changes the *order* of the milestones; both change the size
+of one.
+
+## Tartarus -- drone ledger
+
+<!-- TARTARUS:BEGIN -->
+### Wave 1 - dependency and co-location graph across the 46 entries
+`gemma4:latest` · 2026-08-20 07:57 · wave wall-clock **55.65s**
+
+**Question:** Which entries block which, and which touch the same files?
+
+| Drone | Focus | Status | In (tok) | Out (tok) | Wall (s) | Retries |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| Cottus | every file path, stated dependency, cross-reference and code identifier in these register rows | delivered | 1466 | 2029 | 48.33 | 0 |
+| Briareus | every file path, stated dependency, cross-reference and code identifier in these register rows | delivered | 1423 | 1494 | 38.92 | 0 |
+| Gyges | every file path, stated dependency, cross-reference and code identifier in these register rows | delivered | 1266 | 767 | 23.73 | 0 |
+| Brontes | every file path, stated dependency, cross-reference and code identifier in these register rows | delivered | 1262 | 2518 | 55.65 | 0 |
+
+**Zeus (Claude) since the last wave:** `claude-opus-5`, `claude-sonnet-5` · 44 turn(s) + 32 subagent turn(s) · 644,312 in (new) · 53,477 out · 22,781 of it thinking · 8,049,223 cache-read
+
+### Synthesis and drafting
+_Claude only, no drones_ · 2026-08-20 07:59
+
+**Zeus (Claude) since the last wave:** `claude-opus-5` · 21 turn(s) · 30,300 in (new) · 25,338 out · 11,272 of it thinking · 3,880,000 cache-read
+
+### Totals by drone
+
+| Drone | Waves | In (tok) | Out (tok) | Drone-seconds | Failed |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Briareus | 1 | 1423 | 1494 | 38.92 | 0 |
+| Brontes | 1 | 1262 | 2518 | 55.65 | 0 |
+| Cottus | 1 | 1466 | 2029 | 48.33 | 0 |
+| Gyges | 1 | 1266 | 767 | 23.73 | 0 |
+| **All drones** | 1 waves | **5417** | **6808** | **166.63** | 0 |
+
+**Fleet total:** 1 wave(s) · 5,417 in / 6,808 out tokens · 55.6s elapsed, of which 147.1s was generation.
+
+### Zeus (Claude) totals
+
+| | Turns | In, new (tok) | Out (tok) | of it thinking | Cache-read (tok) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| **Claude** | 97 | 674,612 | 78,815 | 34,053 | 11,929,223 |
+
+Models: `claude-opus-5` (65), `claude-sonnet-5` (32). 32 of those turns were subagents.
+
+**What the offload bought:** the drones read 5,417 tokens of source material that never entered Claude's context, and returned 6,808 tokens of structured extract in its place.
+
+<!-- TARTARUS:END -->
+
+_Claude's own usage is metered into the ledger above, per wave, from the session
+transcript. It is measured, not estimated, which is why it sits in the same
+table as the drone figures rather than in a footnote beneath them._
+
+## What we could not establish
+
+1. **Which side of issue #10 moves** — namespace the controllers under
+   `Api::`, or drop `namespace :api` and keep flat controllers.
+   `DOCS/ISSUE_web_api_wiring.md` presents this as an open decision with a real
+   trade-off (room for `/api/v2` versus a smaller diff), and both are viable.
+   **Not researchable** — there is no source that settles a preference. It
+   changes M1's size, not its position in the chain.
+2. **Whether TIM ships native or is web-only.** This single answer is the
+   difference between M6 being an afternoon (delete the native targets) and a
+   week (replace four web-only call sites). Also a product decision rather than
+   a fact.
+3. **Effort per milestone.** Sizes in the report come from reading the code, not
+   from having done the work. The *ordering* does not rest on them — it rests on
+   the dependency graph — but any schedule built from it would.
+4. **Whether the checks pass.** Every milestone is defined by an observable
+   check, and not one of them has been run, because M0 does not exist yet. The
+   report claims the checks are well-formed, not that they were watched.
+
+Items 1 and 2 are the only two that could reasonably be called decisive, and
+both are decisive for *sizing*, not for order. Neither was researched, and the
+reason in both cases is that the answer lives with the operator rather than in
+any material a wave could reach.


### PR DESCRIPTION
Records what is actually wrong with TIM today, and puts it in an order that can be worked.

## What's in it

**`DOCS/TO_DO.md`** — the four open GitHub issues as separate items, plus a new
`Code Issues Found` section holding 35 defects found by reading the whole
codebase. Every file:line citation was verified against source.

**`dossiers/tim-issue-milestones/`** — sequences all 46 tracked entries into ten
milestones: a chain of five fixed by dependency, plus five independents.
`report.md` is the argument; `research.md` carries the evidence, the decision
rule (written before the research, not after), and the usage ledger.

**`README.md`** — notes that migrations need `docker compose restart api`.

## Two findings worth reading before picking anything up

**Fixing #10 does not make the app work.** Its write-up says it unblocks most of
the sweep, which is true — but `GET /api/jobs` still returns 500 afterwards,
because the controller reads `organization_id`, `job.color` and `job.notes`, and
none of the three exists. They have to ship together.

**Nothing here can currently be verified.** `API/.github/workflows/ci.yml` is not
at the repository root, so Actions has never run it. The 35 existing tests are
all model tests; `test/controllers/` holds only a `.keep`. That is why the first
milestone is the test harness rather than a bug fix — its success condition is a
CI run that goes *red*.

## Deduplication

Anything already covered by issues #4, #5, #6 or #10, or by the existing to-do
lists, is excluded. Seven new items sit close to an existing one and carry an
explicit differentiator — e.g. "save button [DONE]" is true, the button exists;
it just calls `router.push` and discards all four fields.

## Notes for review

- Docs only — no code changes.
- `.waves/*.json` is raw extraction output kept as the audit trail for
  `research.md`. Fine to skim past.
- Two things in the dossier are deliberately unresearched: which side of #10
  moves, and whether TIM ships native. Both are product decisions, not facts;
  each changes a milestone's size, neither changes the order.
